### PR TITLE
feat: add documentation for 19 new UI components

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Bun
-        uses:oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - name: Install dependencies

--- a/src/docs/components/Accordion.mdx
+++ b/src/docs/components/Accordion.mdx
@@ -1,0 +1,116 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import {
+  LoadedCode,
+  GITHUB_DIR_COMP,
+  GITHUB_STORY,
+} from "@/components/LoadedCode";
+import Examples from "./AccordionBlocks/Examples";
+
+# Accordion
+
+A collapsible accordion component.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Accordion", "Accordion")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new directory named `Accordion` in your component folder.
+2. Create following files in the folder, and paste the code into the file.
+
+- `index.ts`
+  <LoadedCode from={GITHUB_DIR_COMP("Accordion", "index.ts")} />
+- `Context.ts`
+  <LoadedCode from={GITHUB_DIR_COMP("Accordion", "Context.ts")} />
+- `Component.tsx`
+  <LoadedCode from={GITHUB_DIR_COMP("Accordion", "Component.tsx")} />
+
+## Usage
+
+```tsx
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@components/Accordion";
+```
+
+```html
+<Accordion>
+  <AccordionItem value="item-1">
+    <AccordionTrigger>Item 1</AccordionTrigger>
+    <AccordionContent>Content for item 1.</AccordionContent>
+  </AccordionItem>
+</Accordion>
+```
+
+## Props
+
+### Accordion
+
+| Prop              | Type                              | Default     | Description                  |
+| :--------------- | :------------------------------- | :---------- | :-------------------------- |
+| `defaultValue`    | `string`                         | -           | Default expanded item value |
+| `value`           | `string`                         | -           | Controlled expanded value   |
+| `onValueChange`   | `(value: string \| null) => void` | -           | Callback when value changes |
+| `collapsible`     | `boolean`                        | `false`     | Allows collapsing all items |
+
+### AccordionItem
+
+| Prop       | Type      | Default | Description                |
+| :-------- | :-------- | :------ | :------------------------ |
+| `value`    | `string`  | -       | Unique value for the item  |
+| `disabled` | `boolean` | -       | Disables the item         |
+
+### AccordionTrigger
+
+Standard button props.
+
+### AccordionContent
+
+Standard div props.
+
+## Examples
+
+### Collapsible
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Collapsible />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Accordion", "Accordion")} />
+  </TabContent>
+</TabProvider>
+
+### Default Expanded
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.DefaultExpanded />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Accordion", "Accordion")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/AccordionBlocks/Examples/Accordion.tsx
+++ b/src/docs/components/AccordionBlocks/Examples/Accordion.tsx
@@ -1,0 +1,59 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@pswui/Accordion";
+
+export const Default = () => {
+  return (
+    <Accordion>
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Item 1</AccordionTrigger>
+        <AccordionContent>
+          Content for item 1.
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionTrigger>Item 2</AccordionTrigger>
+        <AccordionContent>
+          Content for item 2.
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-3">
+        <AccordionTrigger>Item 3</AccordionTrigger>
+        <AccordionContent>
+          Content for item 3.
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+export const Collapsible = () => {
+  return (
+    <Accordion collapsible>
+      <AccordionItem value="open">
+        <AccordionTrigger>Click to toggle</AccordionTrigger>
+        <AccordionContent>
+          This content can be collapsed by clicking the trigger again.
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};
+
+export const DefaultExpanded = () => {
+  return (
+    <Accordion defaultValue="item-2">
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Item 1 (collapsed)</AccordionTrigger>
+        <AccordionContent>Content for item 1.</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionTrigger>Item 2 (expanded)</AccordionTrigger>
+        <AccordionContent>Content for item 2.</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/src/docs/components/AccordionBlocks/Examples/index.ts
+++ b/src/docs/components/AccordionBlocks/Examples/index.ts
@@ -1,0 +1,7 @@
+import { Default, Collapsible, DefaultExpanded } from "./Accordion";
+
+export default {
+  Default,
+  Collapsible,
+  DefaultExpanded,
+};

--- a/src/docs/components/Alert.mdx
+++ b/src/docs/components/Alert.mdx
@@ -1,0 +1,117 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./AlertBlocks/Examples";
+
+# Alert
+
+Displays a callout for important information.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Alert", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Alert.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Alert")} />
+
+## Usage
+
+```tsx
+import { Alert, AlertTitle, AlertDescription } from "@components/Alert";
+```
+
+```html
+<Alert status="default">
+  <AlertTitle>Alert Title</AlertTitle>
+  <AlertDescription>Alert description text.</AlertDescription>
+</Alert>
+```
+
+## Props
+
+### Alert
+
+| Prop      | Type                                                    | Default     | Description                    |
+| :-------- | :------------------------------------------------------ | :---------- | :------------------------------ |
+| `status`  | `"default" \| "success" \| "warning" \| "danger"`       | `"default"` | The status variant of the alert |
+| `asChild` | `boolean`                                              | `false`     | Render as child of a parent     |
+
+### AlertTitle
+
+| Prop      | Type      | Default | Description                  |
+| :-------- | :-------- | :------ | :---------------------------- |
+| `asChild` | `boolean` | `false` | Render as child of a parent   |
+
+### AlertDescription
+
+| Prop      | Type      | Default | Description                  |
+| :-------- | :-------- | :------ | :---------------------------- |
+| `asChild` | `boolean` | `false` | Render as child of a parent  |
+
+## Examples
+
+### Success
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Success />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Alert", "Success")} />
+  </TabContent>
+</TabProvider>
+
+### Warning
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Warning />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Alert", "Warning")} />
+  </TabContent>
+</TabProvider>
+
+### Danger
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Danger />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Alert", "Danger")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/AlertBlocks/Examples/Alert.tsx
+++ b/src/docs/components/AlertBlocks/Examples/Alert.tsx
@@ -1,0 +1,37 @@
+import { Alert, AlertTitle, AlertDescription } from "@pswui/Alert";
+
+export const Default = () => {
+  return (
+    <Alert>
+      <AlertTitle>Default Alert</AlertTitle>
+      <AlertDescription>This is a default alert message.</AlertDescription>
+    </Alert>
+  );
+};
+
+export const Success = () => {
+  return (
+    <Alert status="success">
+      <AlertTitle>Success</AlertTitle>
+      <AlertDescription>Your changes have been saved successfully.</AlertDescription>
+    </Alert>
+  );
+};
+
+export const Warning = () => {
+  return (
+    <Alert status="warning">
+      <AlertTitle>Warning</AlertTitle>
+      <AlertDescription>Please review your input before proceeding.</AlertDescription>
+    </Alert>
+  );
+};
+
+export const Danger = () => {
+  return (
+    <Alert status="danger">
+      <AlertTitle>Error</AlertTitle>
+      <AlertDescription>Something went wrong. Please try again.</AlertDescription>
+    </Alert>
+  );
+};

--- a/src/docs/components/AlertBlocks/Examples/index.ts
+++ b/src/docs/components/AlertBlocks/Examples/index.ts
@@ -1,0 +1,8 @@
+import { Default, Success, Warning, Danger } from "./Alert";
+
+export default {
+  Default,
+  Success,
+  Warning,
+  Danger,
+};

--- a/src/docs/components/Avatar.mdx
+++ b/src/docs/components/Avatar.mdx
@@ -1,0 +1,105 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./AvatarBlocks/Examples";
+
+# Avatar
+
+Displays a user's profile picture or fallback initials.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Avatar", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Avatar.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Avatar")} />
+
+## Usage
+
+```tsx
+import { Avatar } from "@components/Avatar";
+```
+
+```html
+<Avatar name="Shinwoo Park" />
+```
+
+## Props
+
+| Prop          | Type                                 | Default   | Description                         |
+| :------------ | :----------------------------------- | :-------- | :---------------------------------- |
+| `src`         | `string`                             | -         | Image URL                          |
+| `alt`         | `string`                             | -         | Alt text for the image              |
+| `name`        | `string`                             | -         | Name for generating initials        |
+| `fallback`    | `React.ReactNode`                    | -         | Custom fallback content             |
+| `imageProps`  | `AvatarImageProps`                   | -         | Props passed to the img element     |
+| `size`        | `"sm" \| "md" \| "lg"`               | `"md"`    | The size of the avatar              |
+| `shape`       | `"circle" \| "square"`               | `"circle"` | The shape of the avatar            |
+
+## Examples
+
+### With Image
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.WithImage />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Avatar", "WithImage")} />
+  </TabContent>
+</TabProvider>
+
+### Sizes
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Sizes />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Avatar", "Sizes")} />
+  </TabContent>
+</TabProvider>
+
+### Shapes
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Shapes />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Avatar", "Shapes")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/AvatarBlocks/Examples/Avatar.tsx
+++ b/src/docs/components/AvatarBlocks/Examples/Avatar.tsx
@@ -1,0 +1,34 @@
+import { Avatar } from "@pswui/Avatar";
+
+export const Default = () => {
+  return <Avatar name="Shinwoo Park" />;
+};
+
+export const WithImage = () => {
+  return (
+    <Avatar
+      src="https://avatars.githubusercontent.com/u/12345"
+      name="Shinwoo Park"
+      alt="Shinwoo Park's avatar"
+    />
+  );
+};
+
+export const Sizes = () => {
+  return (
+    <div className="flex items-center gap-4">
+      <Avatar name="Small User" size="sm" />
+      <Avatar name="Medium User" size="md" />
+      <Avatar name="Large User" size="lg" />
+    </div>
+  );
+};
+
+export const Shapes = () => {
+  return (
+    <div className="flex items-center gap-4">
+      <Avatar name="Circle" shape="circle" />
+      <Avatar name="Square" shape="square" />
+    </div>
+  );
+};

--- a/src/docs/components/AvatarBlocks/Examples/index.ts
+++ b/src/docs/components/AvatarBlocks/Examples/index.ts
@@ -1,0 +1,8 @@
+import { Default, WithImage, Sizes, Shapes } from "./Avatar";
+
+export default {
+  Default,
+  WithImage,
+  Sizes,
+  Shapes,
+};

--- a/src/docs/components/Badge.mdx
+++ b/src/docs/components/Badge.mdx
@@ -1,0 +1,84 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./BadgeBlocks/Examples";
+
+# Badge
+
+Displays a badge or label.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Badge", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Badge.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Badge")} />
+
+## Usage
+
+```tsx
+import { Badge } from "@components/Badge";
+```
+
+```html
+<Badge status="default">Badge</Badge>
+```
+
+## Props
+
+| Prop      | Type                                           | Default   | Description                    |
+| :-------- | :-------------------------------------------- | :-------- | :----------------------------- |
+| `size`    | `"sm" \| "md"`                                | `"md"`    | The size of the badge          |
+| `status`  | `"default" \| "success" \| "warning" \| "danger"` | `"default"` | The status variant of the badge |
+| `asChild` | `boolean`                                     | `false`   | Render as child of a parent    |
+
+## Examples
+
+### Status Variants
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.StatusVariants />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Badge", "StatusVariants")} />
+  </TabContent>
+</TabProvider>
+
+### Sizes
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Sizes />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Badge", "Sizes")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/BadgeBlocks/Examples/Badge.tsx
+++ b/src/docs/components/BadgeBlocks/Examples/Badge.tsx
@@ -1,0 +1,25 @@
+import { Badge } from "@pswui/Badge";
+
+export const Default = () => {
+  return <Badge>Default</Badge>;
+};
+
+export const StatusVariants = () => {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Badge status="default">Default</Badge>
+      <Badge status="success">Success</Badge>
+      <Badge status="warning">Warning</Badge>
+      <Badge status="danger">Danger</Badge>
+    </div>
+  );
+};
+
+export const Sizes = () => {
+  return (
+    <div className="flex items-center gap-2">
+      <Badge size="sm">Small</Badge>
+      <Badge size="md">Medium</Badge>
+    </div>
+  );
+};

--- a/src/docs/components/BadgeBlocks/Examples/index.ts
+++ b/src/docs/components/BadgeBlocks/Examples/index.ts
@@ -1,0 +1,7 @@
+import { Default, StatusVariants, Sizes } from "./Badge";
+
+export default {
+  Default,
+  StatusVariants,
+  Sizes,
+};

--- a/src/docs/components/Breadcrumb.mdx
+++ b/src/docs/components/Breadcrumb.mdx
@@ -1,0 +1,52 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./BreadcrumbBlocks/Examples";
+
+# Breadcrumb
+
+Displays a navigation path with links.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Breadcrumb", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Breadcrumb.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Breadcrumb")} />
+
+## Usage
+
+```tsx
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@components/Breadcrumb";
+```
+
+```html
+<Breadcrumb>
+  <BreadcrumbList>
+    <BreadcrumbItem><BreadcrumbLink href="#">Home</BreadcrumbLink></BreadcrumbItem>
+    <BreadcrumbSeparator />
+    <BreadcrumbItem><BreadcrumbPage>Current</BreadcrumbPage></BreadcrumbItem>
+  </BreadcrumbList>
+</Breadcrumb>
+```
+
+## Props
+
+Exports: `Breadcrumb`, `BreadcrumbItem`, `BreadcrumbLink`, `BreadcrumbList`, `BreadcrumbPage`, `BreadcrumbSeparator`
+
+All components accept standard HTML props.

--- a/src/docs/components/BreadcrumbBlocks/Examples/Breadcrumb.tsx
+++ b/src/docs/components/BreadcrumbBlocks/Examples/Breadcrumb.tsx
@@ -1,0 +1,28 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@pswui/Breadcrumb";
+
+export const Default = () => {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+};

--- a/src/docs/components/BreadcrumbBlocks/Examples/index.ts
+++ b/src/docs/components/BreadcrumbBlocks/Examples/index.ts
@@ -1,0 +1,5 @@
+import { Default } from "./Breadcrumb";
+
+export default {
+  Default,
+};

--- a/src/docs/components/Card.mdx
+++ b/src/docs/components/Card.mdx
@@ -1,0 +1,60 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./CardBlocks/Examples";
+
+# Card
+
+Displays a card container with header, content, and footer sections.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Card", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Card.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Card")} />
+
+## Usage
+
+```tsx
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from "@components/Card";
+```
+
+```html
+<Card>
+  <CardHeader>
+    <CardTitle>Title</CardTitle>
+    <CardDescription>Description</CardDescription>
+  </CardHeader>
+  <CardContent>Content</CardContent>
+  <CardFooter>Footer</CardFooter>
+</Card>
+```
+
+## Props
+
+Exports: `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent`, `CardFooter`
+
+| Component          | Props          |
+| :----------------- | :------------- |
+| `Card`            | `asChild`     |
+| `CardHeader`       | `asChild`     |
+| `CardTitle`        | `asChild`     |
+| `CardDescription`  | `asChild`     |
+| `CardContent`      | `asChild`     |
+| `CardFooter`       | `asChild`     |

--- a/src/docs/components/CardBlocks/Examples/Card.tsx
+++ b/src/docs/components/CardBlocks/Examples/Card.tsx
@@ -1,0 +1,26 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@pswui/Card";
+import { Button } from "@pswui/Button";
+
+export const Default = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Card Title</CardTitle>
+        <CardDescription>Card description goes here.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>Card content paragraph.</p>
+      </CardContent>
+      <CardFooter>
+        <Button preset="default">Action</Button>
+      </CardFooter>
+    </Card>
+  );
+};

--- a/src/docs/components/CardBlocks/Examples/index.ts
+++ b/src/docs/components/CardBlocks/Examples/index.ts
@@ -1,0 +1,5 @@
+import { Default } from "./Card";
+
+export default {
+  Default,
+};

--- a/src/docs/components/Form.mdx
+++ b/src/docs/components/Form.mdx
@@ -1,0 +1,88 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./FormBlocks/Examples";
+
+# Form
+
+Form layout components with built-in validation support.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Form", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Form.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Form")} />
+
+## Usage
+
+```tsx
+import { FormItem, FormLabel, FormHelper, FormError } from "@components/Form";
+```
+
+```html
+<FormItem invalid={errorMessage}>
+  <FormLabel>Label</FormLabel>
+  <Input placeholder="Input" />
+  <FormHelper>Helper text</FormHelper>
+  <FormError />
+</FormItem>
+```
+
+## Props
+
+### FormItem
+
+| Prop     | Type                    | Default | Description                |
+| :------ | :---------------------- | :------ | :------------------------ |
+| `invalid` | `string \| null`        | -       | Error message              |
+| `asChild` | `boolean`              | -       | Render as child            |
+
+### FormLabel
+
+Standard span props plus `asChild`.
+
+### FormHelper
+
+| Prop           | Type      | Default | Description                   |
+| :------------ | :-------- | :------ | :--------------------------- |
+| `hiddenOnInvalid` | `boolean` | -   | Hide when FormItem is invalid |
+| `asChild`       | `boolean` | -       | Render as child               |
+
+### FormError
+
+Standard span props.
+
+## Examples
+
+### With Error
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.WithError />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Form", "WithError")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/FormBlocks/Examples/Form.tsx
+++ b/src/docs/components/FormBlocks/Examples/Form.tsx
@@ -1,0 +1,23 @@
+import { FormError, FormHelper, FormItem, FormLabel } from "@pswui/Form";
+import { Input } from "@pswui/Input";
+
+export const Default = () => {
+  return (
+    <FormItem invalid={null}>
+      <FormLabel>Email</FormLabel>
+      <Input type="email" placeholder="you@example.com" />
+      <FormHelper>Enter your email address.</FormHelper>
+    </FormItem>
+  );
+};
+
+export const WithError = () => {
+  return (
+    <FormItem invalid="This field is required.">
+      <FormLabel>Username</FormLabel>
+      <Input type="text" placeholder="username" />
+      <FormError />
+      <FormHelper hiddenOnInvalid>Enter a username.</FormHelper>
+    </FormItem>
+  );
+};

--- a/src/docs/components/FormBlocks/Examples/index.ts
+++ b/src/docs/components/FormBlocks/Examples/index.ts
@@ -1,0 +1,6 @@
+import { Default, WithError } from "./Form";
+
+export default {
+  Default,
+  WithError,
+};

--- a/src/docs/components/Pagination.mdx
+++ b/src/docs/components/Pagination.mdx
@@ -1,0 +1,51 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./PaginationBlocks/Examples";
+
+# Pagination
+
+Displays a pagination control for navigating pages.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Pagination", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Pagination.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Pagination")} />
+
+## Usage
+
+```tsx
+import { Pagination, PaginationContent, PaginationItem, PaginationLink, PaginationPrevious, PaginationNext, PaginationEllipsis } from "@components/Pagination";
+```
+
+```html
+<Pagination>
+  <PaginationContent>
+    <PaginationItem><PaginationPrevious href="#" /></PaginationItem>
+    <PaginationItem><PaginationLink href="#">1</PaginationLink></PaginationItem>
+    <PaginationItem><PaginationEllipsis /></PaginationItem>
+    <PaginationItem><PaginationNext href="#" /></PaginationItem>
+  </PaginationContent>
+</Pagination>
+```
+
+## Props
+
+Exports: `Pagination`, `PaginationContent`, `PaginationItem`, `PaginationLink`, `PaginationPrevious`, `PaginationNext`, `PaginationEllipsis`

--- a/src/docs/components/PaginationBlocks/Examples/Pagination.tsx
+++ b/src/docs/components/PaginationBlocks/Examples/Pagination.tsx
@@ -1,0 +1,31 @@
+import { Pagination, PaginationContent, PaginationEllipsis, PaginationItem, PaginationLink, PaginationNext, PaginationPrevious } from "@pswui/Pagination";
+
+export const Default = () => {
+  return (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" active>3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">10</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+};

--- a/src/docs/components/PaginationBlocks/Examples/index.ts
+++ b/src/docs/components/PaginationBlocks/Examples/index.ts
@@ -1,0 +1,5 @@
+import { Default } from "./Pagination";
+
+export default {
+  Default,
+};

--- a/src/docs/components/Progress.mdx
+++ b/src/docs/components/Progress.mdx
@@ -1,0 +1,48 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./ProgressBlocks/Examples";
+
+# Progress
+
+Displays a progress bar.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Progress", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Progress.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Progress")} />
+
+## Usage
+
+```tsx
+import { Progress } from "@components/Progress";
+```
+
+```html
+<Progress value={50} />
+```
+
+## Props
+
+| Prop    | Type              | Default | Description              |
+| :------ | :--------------- | :------ | :---------------------- |
+| `max`   | `number`         | `100`   | Maximum value           |
+| `value` | `number \| null` | -       | Current value           |
+| `size`  | `"sm" \| "md" \| "lg"` | `"md"` | Size of the progress bar |

--- a/src/docs/components/ProgressBlocks/Examples/Progress.tsx
+++ b/src/docs/components/ProgressBlocks/Examples/Progress.tsx
@@ -1,0 +1,15 @@
+import { Progress } from "@pswui/Progress";
+
+export const Default = () => {
+  return <Progress value={50} />;
+};
+
+export const Sizes = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <Progress size="sm" value={70} />
+      <Progress size="md" value={50} />
+      <Progress size="lg" value={30} />
+    </div>
+  );
+};

--- a/src/docs/components/ProgressBlocks/Examples/index.ts
+++ b/src/docs/components/ProgressBlocks/Examples/index.ts
@@ -1,0 +1,6 @@
+import { Default, Sizes } from "./Progress";
+
+export default {
+  Default,
+  Sizes,
+};

--- a/src/docs/components/RadioGroup.mdx
+++ b/src/docs/components/RadioGroup.mdx
@@ -1,0 +1,82 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./RadioGroupBlocks/Examples";
+
+# RadioGroup
+
+A group of radio buttons for single selection.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("RadioGroup", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `RadioGroup.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("RadioGroup")} />
+
+## Usage
+
+```tsx
+import { RadioGroup, RadioGroupItem } from "@components/RadioGroup";
+```
+
+```html
+<RadioGroup defaultValue="option-1">
+  <RadioGroupItem value="option-1">Option 1</RadioGroupItem>
+  <RadioGroupItem value="option-2">Option 2</RadioGroupItem>
+</RadioGroup>
+```
+
+## Props
+
+### RadioGroup
+
+| Prop              | Type                              | Default        | Description                  |
+| :--------------- | :------------------------------- | :------------- | :-------------------------- |
+| `orientation`     | `"horizontal" \| "vertical"`     | `"vertical"`   | Group orientation           |
+| `defaultValue`    | `string`                         | -              | Default selected value      |
+| `value`           | `string`                         | -              | Controlled selected value   |
+| `onValueChange`   | `(value: string) => void`        | -              | Callback when value changes |
+| `disabled`       | `boolean`                        | -              | Disables all items          |
+| `name`           | `string`                         | -              | Group name                  |
+
+### RadioGroupItem
+
+| Prop       | Type      | Default | Description          |
+| :-------- | :-------- | :------ | :------------------ |
+| `value`   | `string`  | -       | Unique value        |
+| `disabled` | `boolean` | -       | Disables the item   |
+
+## Examples
+
+### Horizontal
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Horizontal />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("RadioGroup", "Horizontal")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/RadioGroupBlocks/Examples/RadioGroup.tsx
+++ b/src/docs/components/RadioGroupBlocks/Examples/RadioGroup.tsx
@@ -1,0 +1,21 @@
+import { RadioGroup, RadioGroupItem } from "@pswui/RadioGroup";
+
+export const Default = () => {
+  return (
+    <RadioGroup defaultValue="option-1">
+      <RadioGroupItem value="option-1">Option 1</RadioGroupItem>
+      <RadioGroupItem value="option-2">Option 2</RadioGroupItem>
+      <RadioGroupItem value="option-3">Option 3</RadioGroupItem>
+    </RadioGroup>
+  );
+};
+
+export const Horizontal = () => {
+  return (
+    <RadioGroup orientation="horizontal" defaultValue="a">
+      <RadioGroupItem value="a">A</RadioGroupItem>
+      <RadioGroupItem value="b">B</RadioGroupItem>
+      <RadioGroupItem value="c">C</RadioGroupItem>
+    </RadioGroup>
+  );
+};

--- a/src/docs/components/RadioGroupBlocks/Examples/index.ts
+++ b/src/docs/components/RadioGroupBlocks/Examples/index.ts
@@ -1,0 +1,6 @@
+import { Default, Horizontal } from "./RadioGroup";
+
+export default {
+  Default,
+  Horizontal,
+};

--- a/src/docs/components/ScrollArea.mdx
+++ b/src/docs/components/ScrollArea.mdx
@@ -1,0 +1,48 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./ScrollAreaBlocks/Examples";
+
+# ScrollArea
+
+A container with styled scrollbars.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("ScrollArea", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `ScrollArea.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("ScrollArea")} />
+
+## Usage
+
+```tsx
+import { ScrollArea } from "@components/ScrollArea";
+```
+
+```html
+<ScrollArea className="h-40 w-80">
+  <p>Scrollable content...</p>
+</ScrollArea>
+```
+
+## Props
+
+| Prop         | Type                                   | Default      | Description                |
+| :----------- | :------------------------------------ | :----------- | :------------------------ |
+| `orientation` | `"vertical" \| "horizontal" \| "both"` | `"vertical"` | Scroll orientation        |

--- a/src/docs/components/ScrollAreaBlocks/Examples/ScrollArea.tsx
+++ b/src/docs/components/ScrollAreaBlocks/Examples/ScrollArea.tsx
@@ -1,0 +1,22 @@
+import { ScrollArea } from "@pswui/ScrollArea";
+
+export const Default = () => {
+  return (
+    <ScrollArea className="h-40 w-80">
+      <div className="p-4">
+        <p className="mb-4 text-sm text-neutral-500 dark:text-neutral-400">
+          Scroll area content. The area has a custom scrollbar styled to match
+          the design system. Try scrolling to see the scrollbar appear.
+        </p>
+        <p className="mb-4 text-sm text-neutral-500 dark:text-neutral-400">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+          nisi ut aliquip ex ea commodo consequat.
+        </p>
+      </div>
+    </ScrollArea>
+  );
+};

--- a/src/docs/components/ScrollAreaBlocks/Examples/index.ts
+++ b/src/docs/components/ScrollAreaBlocks/Examples/index.ts
@@ -1,0 +1,5 @@
+import { Default } from "./ScrollArea";
+
+export default {
+  Default,
+};

--- a/src/docs/components/Select.mdx
+++ b/src/docs/components/Select.mdx
@@ -1,0 +1,102 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./SelectBlocks/Examples";
+
+# Select
+
+A dropdown select component.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Select", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Select.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Select")} />
+
+## Usage
+
+```tsx
+import { Select } from "@components/Select";
+import type { SelectOption } from "@components/Select";
+```
+
+```tsx
+const options: SelectOption[] = [
+  { label: "Option 1", value: "1" },
+  { label: "Option 2", value: "2" },
+];
+<Select options={options} placeholder="Select an option" />
+```
+
+## Props
+
+| Prop         | Type                                | Default         | Description                    |
+| :---------- | :--------------------------------- | :-------------- | :----------------------------- |
+| `options`    | `SelectOption[]`                    | -               | List of selectable options     |
+| `value`      | `string`                            | -               | Controlled selected value      |
+| `defaultValue` | `string`                         | -               | Default selected value        |
+| `onValueChange` | `(value: string) => void`        | -               | Callback when value changes    |
+| `placeholder` | `React.ReactNode`                  | `"Select an option"` | Placeholder text           |
+| `full`       | `boolean`                           | `false`         | Full width                    |
+
+### SelectOption
+
+```ts
+interface SelectOption {
+  label: React.ReactNode;
+  value: string;
+  disabled?: boolean;
+}
+```
+
+## Examples
+
+### With Default Value
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.WithDefaultValue />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Select", "WithDefaultValue")} />
+  </TabContent>
+</TabProvider>
+
+### Full Width
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.FullWidth />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Select", "FullWidth")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/SelectBlocks/Examples/Select.tsx
+++ b/src/docs/components/SelectBlocks/Examples/Select.tsx
@@ -1,0 +1,40 @@
+import { Select } from "@pswui/Select";
+
+export const Default = () => {
+  return (
+    <Select
+      placeholder="Select an option"
+      options={[
+        { label: "Option 1", value: "1" },
+        { label: "Option 2", value: "2" },
+        { label: "Option 3", value: "3" },
+      ]}
+    />
+  );
+};
+
+export const WithDefaultValue = () => {
+  return (
+    <Select
+      defaultValue="2"
+      options={[
+        { label: "Option 1", value: "1" },
+        { label: "Option 2", value: "2" },
+        { label: "Option 3", value: "3" },
+      ]}
+    />
+  );
+};
+
+export const FullWidth = () => {
+  return (
+    <Select
+      full
+      placeholder="Full width select"
+      options={[
+        { label: "Long option label 1", value: "1" },
+        { label: "Long option label 2", value: "2" },
+      ]}
+    />
+  );
+};

--- a/src/docs/components/SelectBlocks/Examples/index.ts
+++ b/src/docs/components/SelectBlocks/Examples/index.ts
@@ -1,0 +1,7 @@
+import { Default, WithDefaultValue, FullWidth } from "./Select";
+
+export default {
+  Default,
+  WithDefaultValue,
+  FullWidth,
+};

--- a/src/docs/components/Separator.mdx
+++ b/src/docs/components/Separator.mdx
@@ -1,0 +1,47 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./SeparatorBlocks/Examples";
+
+# Separator
+
+Displays a visual divider.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Separator", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Separator.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Separator")} />
+
+## Usage
+
+```tsx
+import { Separator } from "@components/Separator";
+```
+
+```html
+<Separator />
+```
+
+## Props
+
+| Prop         | Type                              | Default        | Description              |
+| :----------- | :------------------------------- | :------------- | :---------------------- |
+| `orientation` | `"horizontal" \| "vertical"`    | `"horizontal"` | Orientation of the separator |
+| `decorative`  | `boolean`                        | -              | Hides separator from accessibility tree |

--- a/src/docs/components/SeparatorBlocks/Examples/Separator.tsx
+++ b/src/docs/components/SeparatorBlocks/Examples/Separator.tsx
@@ -1,0 +1,21 @@
+import { Separator } from "@pswui/Separator";
+
+export const Default = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <p>Item one</p>
+      <Separator />
+      <p>Item two</p>
+    </div>
+  );
+};
+
+export const Vertical = () => {
+  return (
+    <div className="flex items-center gap-4">
+      <span>Left side</span>
+      <Separator orientation="vertical" />
+      <span>Right side</span>
+    </div>
+  );
+};

--- a/src/docs/components/SeparatorBlocks/Examples/index.ts
+++ b/src/docs/components/SeparatorBlocks/Examples/index.ts
@@ -1,0 +1,6 @@
+import { Default, Vertical } from "./Separator";
+
+export default {
+  Default,
+  Vertical,
+};

--- a/src/docs/components/Skeleton.mdx
+++ b/src/docs/components/Skeleton.mdx
@@ -1,0 +1,83 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./SkeletonBlocks/Examples";
+
+# Skeleton
+
+Displays a loading placeholder.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Skeleton", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Skeleton.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Skeleton")} />
+
+## Usage
+
+```tsx
+import { Skeleton } from "@components/Skeleton";
+```
+
+```html
+<Skeleton />
+```
+
+## Props
+
+| Prop    | Type                                 | Default    | Description                    |
+| :------ | :---------------------------------- | :--------- | :----------------------------- |
+| `shape` | `"rectangle" \| "circle" \| "text"` | `"rectangle"` | Shape of the skeleton       |
+| `size`  | `"sm" \| "md" \| "lg" \| "icon"`    | `"md"`     | Size of the skeleton           |
+
+## Examples
+
+### Shapes
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Shapes />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Skeleton", "Shapes")} />
+  </TabContent>
+</TabProvider>
+
+### Sizes
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Sizes />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Skeleton", "Sizes")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/SkeletonBlocks/Examples/Skeleton.tsx
+++ b/src/docs/components/SkeletonBlocks/Examples/Skeleton.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@pswui/Skeleton";
+
+export const Default = () => {
+  return <Skeleton />;
+};
+
+export const Shapes = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton shape="rectangle" />
+      <Skeleton shape="circle" size="icon" />
+      <Skeleton shape="text" />
+    </div>
+  );
+};
+
+export const Sizes = () => {
+  return (
+    <div className="flex flex-col gap-2">
+      <Skeleton size="sm" />
+      <Skeleton size="md" />
+      <Skeleton size="lg" />
+    </div>
+  );
+};

--- a/src/docs/components/SkeletonBlocks/Examples/index.ts
+++ b/src/docs/components/SkeletonBlocks/Examples/index.ts
@@ -1,0 +1,7 @@
+import { Default, Shapes, Sizes } from "./Skeleton";
+
+export default {
+  Default,
+  Shapes,
+  Sizes,
+};

--- a/src/docs/components/Slider.mdx
+++ b/src/docs/components/Slider.mdx
@@ -1,0 +1,67 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./SliderBlocks/Examples";
+
+# Slider
+
+A slider input for selecting a value within a range.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Slider", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Slider.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Slider")} />
+
+## Usage
+
+```tsx
+import { Slider } from "@components/Slider";
+```
+
+```html
+<Slider defaultValue={[50]} />
+```
+
+## Props
+
+| Prop    | Type                      | Default | Description             |
+| :------ | :------------------------ | :------ | :-------------------- |
+| `size`  | `"sm" \| "md" \| "lg"`   | `"md"`  | Size of the slider    |
+
+Standard input range props apply.
+
+## Examples
+
+### Sizes
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Sizes />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Slider", "Sizes")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/SliderBlocks/Examples/Slider.tsx
+++ b/src/docs/components/SliderBlocks/Examples/Slider.tsx
@@ -1,0 +1,15 @@
+import { Slider } from "@pswui/Slider";
+
+export const Default = () => {
+  return <Slider defaultValue={["50"]} />;
+};
+
+export const Sizes = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <Slider size="sm" defaultValue={["30"]} />
+      <Slider size="md" defaultValue={["50"]} />
+      <Slider size="lg" defaultValue={["70"]} />
+    </div>
+  );
+};

--- a/src/docs/components/SliderBlocks/Examples/index.ts
+++ b/src/docs/components/SliderBlocks/Examples/index.ts
@@ -1,0 +1,6 @@
+import { Default, Sizes } from "./Slider";
+
+export default {
+  Default,
+  Sizes,
+};

--- a/src/docs/components/Table.mdx
+++ b/src/docs/components/Table.mdx
@@ -1,0 +1,49 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./TableBlocks/Examples";
+
+# Table
+
+Displays data in a structured table.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Table", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Table.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Table")} />
+
+## Usage
+
+```tsx
+import { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption } from "@components/Table";
+```
+
+```html
+<Table>
+  <TableCaption>Caption</TableCaption>
+  <TableHeader><TableRow><TableHead>Header</TableHead></TableRow></TableHeader>
+  <TableBody><TableRow><TableCell>Cell</TableCell></TableRow></TableBody>
+  <TableFooter><TableRow><TableCell>Footer</TableCell></TableRow></TableFooter>
+</Table>
+```
+
+## Props
+
+Exports: `Table`, `TableHeader`, `TableBody`, `TableFooter`, `TableHead`, `TableRow`, `TableCell`, `TableCaption`

--- a/src/docs/components/TableBlocks/Examples/Table.tsx
+++ b/src/docs/components/TableBlocks/Examples/Table.tsx
@@ -1,0 +1,43 @@
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@pswui/Table";
+
+export const Default = () => {
+  return (
+    <Table>
+      <TableCaption>Users table</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Name</TableHead>
+          <TableHead>Email</TableHead>
+          <TableHead>Role</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>Shinwoo Park</TableCell>
+          <TableCell>shinwoo@example.com</TableCell>
+          <TableCell>Admin</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Jane Doe</TableCell>
+          <TableCell>jane@example.com</TableCell>
+          <TableCell>Editor</TableCell>
+        </TableRow>
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell>Total</TableCell>
+          <TableCell colSpan={2}>2 users</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  );
+};

--- a/src/docs/components/TableBlocks/Examples/index.ts
+++ b/src/docs/components/TableBlocks/Examples/index.ts
@@ -1,0 +1,5 @@
+import { Default } from "./Table";
+
+export default {
+  Default,
+};

--- a/src/docs/components/Textarea.mdx
+++ b/src/docs/components/Textarea.mdx
@@ -1,0 +1,88 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./TextareaBlocks/Examples";
+
+# Textarea
+
+A multi-line text input component.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Textarea", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Textarea.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Textarea")} />
+
+## Usage
+
+```tsx
+import { Textarea } from "@components/Textarea";
+```
+
+```html
+<Textarea placeholder="Type your message..." />
+```
+
+## Props
+
+| Prop      | Type                              | Default   | Description                   |
+| :------- | :------------------------------- | :-------- | :---------------------------- |
+| `invalid` | `string`                         | -         | Error message for invalid state |
+| `unstyled` | `boolean`                       | `false`   | Remove default styling         |
+| `full`    | `boolean`                        | `false`   | Full width                    |
+
+### TextareaFrame
+
+Wraps textarea in a styled label frame. Same props as Textarea plus `asChild`.
+
+## Examples
+
+### With Error
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.WithError />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Textarea", "WithError")} />
+  </TabContent>
+</TabProvider>
+
+### Full Width
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.FullWidth />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Textarea", "FullWidth")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/TextareaBlocks/Examples/Textarea.tsx
+++ b/src/docs/components/TextareaBlocks/Examples/Textarea.tsx
@@ -1,0 +1,13 @@
+import { Textarea } from "@pswui/Textarea";
+
+export const Default = () => {
+  return <Textarea placeholder="Type your message here." />;
+};
+
+export const WithError = () => {
+  return <Textarea placeholder="Enter description" invalid="This field is required." />;
+};
+
+export const FullWidth = () => {
+  return <Textarea full placeholder="Full width textarea" />;
+};

--- a/src/docs/components/TextareaBlocks/Examples/index.ts
+++ b/src/docs/components/TextareaBlocks/Examples/index.ts
@@ -1,0 +1,7 @@
+import { Default, WithError, FullWidth } from "./Textarea";
+
+export default {
+  Default,
+  WithError,
+  FullWidth,
+};

--- a/src/docs/components/Toggle.mdx
+++ b/src/docs/components/Toggle.mdx
@@ -1,0 +1,49 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./ToggleBlocks/Examples";
+
+# Toggle
+
+A button that toggles between pressed and unpressed states.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("Toggle", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `Toggle.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("Toggle")} />
+
+## Usage
+
+```tsx
+import { Toggle } from "@components/Toggle";
+```
+
+```html
+<Toggle>Toggle</Toggle>
+```
+
+## Props
+
+| Prop               | Type                              | Default      | Description                     |
+| :----------------- | :------------------------------- | :----------- | :------------------------------ |
+| `size`             | `"sm" \| "md" \| "lg"`          | `"md"`       | Size of the toggle               |
+| `pressed`          | `boolean`                        | -            | Controlled pressed state         |
+| `defaultPressed`   | `boolean`                        | `false`      | Default pressed state            |
+| `onPressedChange`  | `(pressed: boolean) => void`     | -            | Callback when pressed state changes |

--- a/src/docs/components/ToggleBlocks/Examples/Toggle.tsx
+++ b/src/docs/components/ToggleBlocks/Examples/Toggle.tsx
@@ -1,0 +1,19 @@
+import { Toggle } from "@pswui/Toggle";
+
+export const Default = () => {
+  return <Toggle>Toggle</Toggle>;
+};
+
+export const Sizes = () => {
+  return (
+    <div className="flex items-center gap-2">
+      <Toggle size="sm">Small</Toggle>
+      <Toggle size="md">Medium</Toggle>
+      <Toggle size="lg">Large</Toggle>
+    </div>
+  );
+};
+
+export const DefaultPressed = () => {
+  return <Toggle defaultPressed>Pressed by default</Toggle>;
+};

--- a/src/docs/components/ToggleBlocks/Examples/index.ts
+++ b/src/docs/components/ToggleBlocks/Examples/index.ts
@@ -1,0 +1,7 @@
+import { Default, Sizes, DefaultPressed } from "./Toggle";
+
+export default {
+  Default,
+  Sizes,
+  DefaultPressed,
+};

--- a/src/docs/components/ToggleGroup.mdx
+++ b/src/docs/components/ToggleGroup.mdx
@@ -1,0 +1,100 @@
+import { TabProvider, TabTrigger, TabContent, TabList } from "@pswui/Tabs";
+import { Story } from "@/components/Story";
+import { LoadedCode, GITHUB_COMP, GITHUB_STORY } from "@/components/LoadedCode";
+import Examples from "./ToggleGroupBlocks/Examples";
+
+# ToggleGroup
+
+A group of toggle buttons that can be controlled individually or as a single selection.
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Default />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("ToggleGroup", "Default")} />
+  </TabContent>
+</TabProvider>
+
+## Installation
+
+1. Create a new file `ToggleGroup.tsx` in your component folder.
+2. Copy and paste the following code into the file.
+
+<LoadedCode from={GITHUB_COMP("ToggleGroup")} />
+
+## Usage
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "@components/ToggleGroup";
+```
+
+```html
+<ToggleGroup>
+  <ToggleGroupItem value="bold">B</ToggleGroupItem>
+  <ToggleGroupItem value="italic">I</ToggleGroupItem>
+</ToggleGroup>
+```
+
+## Props
+
+### ToggleGroup
+
+| Prop        | Type                                        | Default      | Description                        |
+| :--------- | :----------------------------------------- | :----------- | :-------------------------------- |
+| `type`      | `"single" \| "multiple"`                   | `"single"`   | Selection type                    |
+| `value`     | `string \| string[]`                       | -            | Controlled selection value        |
+| `defaultValue` | `string \| string[]`                   | -            | Default selection value           |
+| `onValueChange` | `(value: string \| string[]) => void`  | -            | Callback when selection changes   |
+| `disabled`  | `boolean`                                  | -            | Disables all items                |
+| `size`      | `"sm" \| "md" \| "lg"`                     | -            | Size of all items                 |
+| `orientation` | `"horizontal" \| "vertical"`             | `"horizontal"` | Group orientation               |
+
+### ToggleGroupItem
+
+| Prop       | Type      | Default | Description                |
+| :--------- | :-------- | :------ | :------------------------ |
+| `value`    | `string`  | -       | Unique value for the item  |
+| `disabled` | `boolean` | -       | Disables the item         |
+
+## Examples
+
+### Multiple Selection
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Multiple />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("ToggleGroup", "Multiple")} />
+  </TabContent>
+</TabProvider>
+
+### Vertical
+
+<TabProvider defaultName="preview">
+  <TabList>
+    <TabTrigger name="preview">Preview</TabTrigger>
+    <TabTrigger name="code">Code</TabTrigger>
+  </TabList>
+  <TabContent name="preview">
+    <Story layout="centered">
+      <Examples.Vertical />
+    </Story>
+  </TabContent>
+  <TabContent name="code">
+    <LoadedCode from={GITHUB_STORY("ToggleGroup", "Vertical")} />
+  </TabContent>
+</TabProvider>

--- a/src/docs/components/ToggleGroupBlocks/Examples/ToggleGroup.tsx
+++ b/src/docs/components/ToggleGroupBlocks/Examples/ToggleGroup.tsx
@@ -1,0 +1,31 @@
+import { ToggleGroup, ToggleGroupItem } from "@pswui/ToggleGroup";
+
+export const Default = () => {
+  return (
+    <ToggleGroup>
+      <ToggleGroupItem value="bold">B</ToggleGroupItem>
+      <ToggleGroupItem value="italic">I</ToggleGroupItem>
+      <ToggleGroupItem value="underline">U</ToggleGroupItem>
+    </ToggleGroup>
+  );
+};
+
+export const Multiple = () => {
+  return (
+    <ToggleGroup type="multiple" defaultValue={["bold", "italic"]}>
+      <ToggleGroupItem value="bold">B</ToggleGroupItem>
+      <ToggleGroupItem value="italic">I</ToggleGroupItem>
+      <ToggleGroupItem value="underline">U</ToggleGroupItem>
+    </ToggleGroup>
+  );
+};
+
+export const Vertical = () => {
+  return (
+    <ToggleGroup orientation="vertical">
+      <ToggleGroupItem value="a">Option A</ToggleGroupItem>
+      <ToggleGroupItem value="b">Option B</ToggleGroupItem>
+      <ToggleGroupItem value="c">Option C</ToggleGroupItem>
+    </ToggleGroup>
+  );
+};

--- a/src/docs/components/ToggleGroupBlocks/Examples/index.ts
+++ b/src/docs/components/ToggleGroupBlocks/Examples/index.ts
@@ -1,0 +1,7 @@
+import { Default, Multiple, Vertical } from "./ToggleGroup";
+
+export default {
+  Default,
+  Multiple,
+  Vertical,
+};

--- a/src/pswui/components/Accordion/Component.tsx
+++ b/src/pswui/components/Accordion/Component.tsx
@@ -1,0 +1,226 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+import {
+  AccordionContext,
+  AccordionItemContext,
+  useAccordionContext,
+  useAccordionItemContext,
+} from "./Context";
+
+const [accordionVariant, resolveAccordionVariantProps] = vcn({
+  base: "overflow-hidden rounded-lg border border-neutral-200 bg-white text-neutral-950 shadow-sm dark:border-neutral-800 dark:bg-black dark:text-neutral-50",
+  variants: {},
+  defaults: {},
+});
+
+interface AccordionProps
+  extends VariantProps<typeof accordionVariant>,
+    React.ComponentPropsWithoutRef<"div"> {
+  defaultValue?: string;
+  value?: string | null;
+  onValueChange?: (value: string | null) => void;
+  collapsible?: boolean;
+}
+
+const Accordion = React.forwardRef<HTMLDivElement, AccordionProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveAccordionVariantProps(props);
+    const {
+      defaultValue,
+      value,
+      onValueChange,
+      collapsible = false,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+    const [internalValue, setInternalValue] = React.useState<string | null>(
+      defaultValue ?? null,
+    );
+
+    const currentValue = value !== undefined ? value : internalValue;
+
+    function onItemToggle(nextValue: string) {
+      const resolvedValue =
+        currentValue === nextValue
+          ? collapsible
+            ? null
+            : nextValue
+          : nextValue;
+
+      if (value === undefined) {
+        setInternalValue(resolvedValue);
+      }
+
+      onValueChange?.(resolvedValue);
+    }
+
+    return (
+      <AccordionContext.Provider
+        value={{
+          value: currentValue,
+          collapsible,
+          onItemToggle,
+        }}
+      >
+        <div
+          {...otherPropsExtracted}
+          ref={ref}
+          className={accordionVariant(variantProps)}
+        />
+      </AccordionContext.Provider>
+    );
+  },
+);
+Accordion.displayName = "Accordion";
+
+const [accordionItemVariant, resolveAccordionItemVariantProps] = vcn({
+  base: "overflow-hidden border-b border-neutral-200 last:border-b-0 dark:border-neutral-800",
+  variants: {},
+  defaults: {},
+});
+
+interface AccordionItemProps
+  extends VariantProps<typeof accordionItemVariant>,
+    React.ComponentPropsWithoutRef<"div"> {
+  value: string;
+  disabled?: boolean;
+}
+
+const AccordionItem = React.forwardRef<HTMLDivElement, AccordionItemProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveAccordionItemVariantProps(props);
+    const {
+      value,
+      disabled = false,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+    const { value: activeValue, onItemToggle } = useAccordionContext();
+    const triggerId = React.useId();
+    const contentId = React.useId();
+    const open = activeValue === value;
+
+    return (
+      <AccordionItemContext.Provider
+        value={{
+          value,
+          open,
+          disabled,
+          triggerId,
+          contentId,
+          onToggle: () => {
+            if (disabled) {
+              return;
+            }
+
+            onItemToggle(value);
+          },
+        }}
+      >
+        <div
+          {...otherPropsExtracted}
+          ref={ref}
+          data-disabled={disabled ? "" : undefined}
+          data-state={open ? "open" : "closed"}
+          className={accordionItemVariant(variantProps)}
+        />
+      </AccordionItemContext.Provider>
+    );
+  },
+);
+AccordionItem.displayName = "AccordionItem";
+
+const [accordionTriggerVariant, resolveAccordionTriggerVariantProps] = vcn({
+  base: "flex w-full items-center justify-between gap-4 px-4 py-3 text-left text-sm font-medium transition-colors outline outline-1 outline-transparent outline-offset-2 hover:bg-neutral-50 focus-visible:outline-black/10 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-neutral-950 dark:focus-visible:outline-white/20",
+  variants: {
+    open: {
+      true: "bg-neutral-50 dark:bg-neutral-950",
+      false: "",
+    },
+  },
+  defaults: {
+    open: false,
+  },
+});
+
+interface AccordionTriggerProps
+  extends Omit<VariantProps<typeof accordionTriggerVariant>, "open">,
+    Omit<React.ComponentPropsWithoutRef<"button">, "type"> {}
+
+const AccordionTrigger = React.forwardRef<
+  HTMLButtonElement,
+  AccordionTriggerProps
+>((props, ref) => {
+  const [variantProps, otherPropsCompressed] =
+    resolveAccordionTriggerVariantProps(props);
+  const { onClick, children, ...otherPropsExtracted } = otherPropsCompressed;
+  const { open, disabled, triggerId, contentId, onToggle } =
+    useAccordionItemContext();
+
+  return (
+    <h3 className="flex">
+      <button
+        {...otherPropsExtracted}
+        ref={ref}
+        id={triggerId}
+        type="button"
+        disabled={disabled}
+        aria-controls={contentId}
+        aria-expanded={open}
+        className={accordionTriggerVariant({
+          ...variantProps,
+          open,
+        })}
+        onClick={(event) => {
+          onToggle();
+          onClick?.(event);
+        }}
+      >
+        <span>{children}</span>
+        <span
+          aria-hidden="true"
+          className="text-lg leading-none"
+        >
+          {open ? "-" : "+"}
+        </span>
+      </button>
+    </h3>
+  );
+});
+AccordionTrigger.displayName = "AccordionTrigger";
+
+const [accordionContentVariant, resolveAccordionContentVariantProps] = vcn({
+  base: "px-4 pb-4 text-sm text-neutral-600 dark:text-neutral-300",
+  variants: {},
+  defaults: {},
+});
+
+interface AccordionContentProps
+  extends VariantProps<typeof accordionContentVariant>,
+    React.ComponentPropsWithoutRef<"div"> {}
+
+const AccordionContent = React.forwardRef<
+  HTMLDivElement,
+  AccordionContentProps
+>((props, ref) => {
+  const [variantProps, otherPropsCompressed] =
+    resolveAccordionContentVariantProps(props);
+  const { open, triggerId, contentId } = useAccordionItemContext();
+
+  return (
+    <div
+      {...otherPropsCompressed}
+      ref={ref}
+      id={contentId}
+      role="region"
+      aria-labelledby={triggerId}
+      hidden={!open}
+      data-state={open ? "open" : "closed"}
+      className={accordionContentVariant(variantProps)}
+    />
+  );
+});
+AccordionContent.displayName = "AccordionContent";
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/src/pswui/components/Accordion/Context.ts
+++ b/src/pswui/components/Accordion/Context.ts
@@ -1,0 +1,55 @@
+import { createContext, useContext } from "react";
+
+export interface IAccordionContext {
+  value: string | null;
+  collapsible: boolean;
+  onItemToggle: (value: string) => void;
+}
+
+export const initialAccordionContext: IAccordionContext = {
+  value: null,
+  collapsible: false,
+  onItemToggle: () => {
+    if (process.env.NODE_ENV && process.env.NODE_ENV === "development") {
+      console.warn(
+        "It seems like you're using AccordionContext outside of a provider.",
+      );
+    }
+  },
+};
+
+export const AccordionContext = createContext<IAccordionContext>(
+  initialAccordionContext,
+);
+
+export const useAccordionContext = () => useContext(AccordionContext);
+
+export interface IAccordionItemContext {
+  value: string;
+  open: boolean;
+  disabled: boolean;
+  triggerId: string;
+  contentId: string;
+  onToggle: () => void;
+}
+
+export const initialAccordionItemContext: IAccordionItemContext = {
+  value: "",
+  open: false,
+  disabled: false,
+  triggerId: "",
+  contentId: "",
+  onToggle: () => {
+    if (process.env.NODE_ENV && process.env.NODE_ENV === "development") {
+      console.warn(
+        "It seems like you're using AccordionItemContext outside of a provider.",
+      );
+    }
+  },
+};
+
+export const AccordionItemContext = createContext<IAccordionItemContext>(
+  initialAccordionItemContext,
+);
+
+export const useAccordionItemContext = () => useContext(AccordionItemContext);

--- a/src/pswui/components/Accordion/index.ts
+++ b/src/pswui/components/Accordion/index.ts
@@ -1,0 +1,2 @@
+export * from "./Component";
+export * from "./Context";

--- a/src/pswui/components/Alert.tsx
+++ b/src/pswui/components/Alert.tsx
@@ -1,0 +1,105 @@
+import { type AsChild, Slot, type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [alertVariant, resolveAlertVariantProps] = vcn({
+  base: "flex flex-col gap-2 rounded-lg border p-4 text-neutral-950 shadow-sm dark:text-neutral-50",
+  variants: {
+    status: {
+      default:
+        "border-neutral-200 bg-white dark:border-neutral-800 dark:bg-black",
+      success:
+        "border-green-400 bg-green-50 dark:border-green-600 dark:bg-green-950/40",
+      warning:
+        "border-yellow-400 bg-yellow-50 dark:border-yellow-600 dark:bg-yellow-950/40",
+      danger: "border-red-400 bg-red-50 dark:border-red-600 dark:bg-red-950/40",
+    },
+  },
+  defaults: {
+    status: "default",
+  },
+});
+
+interface AlertProps
+  extends VariantProps<typeof alertVariant>,
+    React.ComponentPropsWithoutRef<"section">,
+    AsChild {}
+
+const Alert = React.forwardRef<HTMLElement, AlertProps>((props, ref) => {
+  const [variantProps, otherPropsCompressed] = resolveAlertVariantProps(props);
+  const { asChild, role, ...otherPropsExtracted } = otherPropsCompressed;
+
+  const Comp = asChild ? Slot : "section";
+
+  return (
+    <Comp
+      ref={ref}
+      role={role ?? "alert"}
+      className={alertVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+Alert.displayName = "Alert";
+
+const [alertTitleVariant, resolveAlertTitleVariantProps] = vcn({
+  base: "text-base font-semibold leading-none tracking-tight",
+  variants: {},
+  defaults: {},
+});
+
+interface AlertTitleProps
+  extends VariantProps<typeof alertTitleVariant>,
+    React.ComponentPropsWithoutRef<"h5">,
+    AsChild {}
+
+const AlertTitle = React.forwardRef<HTMLHeadingElement, AlertTitleProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveAlertTitleVariantProps(props);
+    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "h5";
+
+    return (
+      <Comp
+        ref={ref}
+        className={alertTitleVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+AlertTitle.displayName = "AlertTitle";
+
+const [alertDescriptionVariant, resolveAlertDescriptionVariantProps] = vcn({
+  base: "text-sm text-neutral-600 dark:text-neutral-300",
+  variants: {},
+  defaults: {},
+});
+
+interface AlertDescriptionProps
+  extends VariantProps<typeof alertDescriptionVariant>,
+    React.ComponentPropsWithoutRef<"p">,
+    AsChild {}
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  AlertDescriptionProps
+>((props, ref) => {
+  const [variantProps, otherPropsCompressed] =
+    resolveAlertDescriptionVariantProps(props);
+  const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+  const Comp = asChild ? Slot : "p";
+
+  return (
+    <Comp
+      ref={ref}
+      className={alertDescriptionVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertTitle, AlertDescription };

--- a/src/pswui/components/Avatar.tsx
+++ b/src/pswui/components/Avatar.tsx
@@ -1,0 +1,147 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [avatarVariants, resolveAvatarVariantProps] = vcn({
+  base: "relative inline-flex shrink-0 select-none items-center justify-center overflow-hidden border border-neutral-200 bg-neutral-100 font-medium text-neutral-700 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-200",
+  variants: {
+    size: {
+      sm: "size-8 text-xs",
+      md: "size-10 text-sm",
+      lg: "size-14 text-lg",
+    },
+    shape: {
+      circle: "rounded-full",
+      square: "rounded-lg",
+    },
+  },
+  defaults: {
+    size: "md",
+    shape: "circle",
+  },
+});
+
+type ImageStatus = "idle" | "loading" | "loaded" | "error";
+
+type AvatarImageProps = Omit<
+  React.ComponentPropsWithoutRef<"img">,
+  "alt" | "children" | "src"
+>;
+
+export interface AvatarProps
+  extends VariantProps<typeof avatarVariants>,
+    Omit<React.ComponentPropsWithoutRef<"div">, "children"> {
+  src?: string;
+  alt?: string;
+  name?: string;
+  fallback?: React.ReactNode;
+  imageProps?: AvatarImageProps;
+}
+
+function getInitials(name?: string) {
+  const words = name?.trim().split(/\s+/).filter(Boolean) ?? [];
+
+  if (words.length === 0) {
+    return null;
+  }
+
+  return words
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function getFallbackLabel({
+  alt,
+  name,
+  fallback,
+}: Pick<AvatarProps, "alt" | "name" | "fallback">) {
+  if (alt && alt.length > 0) {
+    return alt;
+  }
+
+  if (name && name.length > 0) {
+    return name;
+  }
+
+  if (typeof fallback === "string" && fallback.length > 0) {
+    return fallback;
+  }
+
+  return "Avatar";
+}
+
+const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>((props, ref) => {
+  const [variantProps, otherPropsCompressed] = resolveAvatarVariantProps(props);
+  const {
+    src,
+    alt,
+    name,
+    fallback,
+    imageProps,
+    role,
+    "aria-hidden": ariaHidden,
+    "aria-label": ariaLabel,
+    ...otherPropsExtracted
+  } = otherPropsCompressed;
+  const isAriaHidden = ariaHidden === true || ariaHidden === "true";
+
+  const [imageStatus, setImageStatus] = React.useState<ImageStatus>(
+    src ? "loading" : "idle",
+  );
+
+  React.useEffect(() => {
+    setImageStatus(src ? "loading" : "idle");
+  }, [src]);
+
+  const fallbackContent = fallback ?? getInitials(name) ?? "?";
+  const fallbackLabel = ariaLabel ?? getFallbackLabel({ alt, name, fallback });
+  const showFallback = !src || imageStatus !== "loaded";
+  const showImage = Boolean(src) && imageStatus !== "error";
+
+  return (
+    <div
+      ref={ref}
+      className={avatarVariants(variantProps)}
+      data-state={showFallback ? "fallback" : "loaded"}
+      role={!isAriaHidden && showFallback ? role ?? "img" : role}
+      aria-hidden={ariaHidden}
+      aria-label={!isAriaHidden && showFallback ? fallbackLabel : ariaLabel}
+      {...otherPropsExtracted}
+    >
+      {showImage ? (
+        <img
+          {...imageProps}
+          src={src}
+          alt={alt ?? name ?? ""}
+          ref={(element) => {
+            if (element?.complete) {
+              setImageStatus(element.naturalWidth > 0 ? "loaded" : "error");
+            }
+          }}
+          className={`absolute inset-0 size-full object-cover ${
+            imageStatus === "loaded" ? "" : "hidden"
+          } ${imageProps?.className ?? ""}`}
+          onLoad={(event) => {
+            setImageStatus("loaded");
+            imageProps?.onLoad?.(event);
+          }}
+          onError={(event) => {
+            setImageStatus("error");
+            imageProps?.onError?.(event);
+          }}
+        />
+      ) : null}
+      {showFallback ? (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none leading-none uppercase"
+        >
+          {fallbackContent}
+        </span>
+      ) : null}
+    </div>
+  );
+});
+Avatar.displayName = "Avatar";
+
+export { Avatar };

--- a/src/pswui/components/Badge.tsx
+++ b/src/pswui/components/Badge.tsx
@@ -1,0 +1,56 @@
+import { type AsChild, Slot, type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const badgeColors = {
+  default:
+    "border-neutral-300 bg-neutral-100 text-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100",
+  success:
+    "border-green-300 bg-green-100 text-green-900 dark:border-green-700 dark:bg-green-900 dark:text-green-100",
+  warning:
+    "border-yellow-300 bg-yellow-100 text-yellow-900 dark:border-yellow-700 dark:bg-yellow-900 dark:text-yellow-100",
+  danger:
+    "border-red-300 bg-red-100 text-red-900 dark:border-red-700 dark:bg-red-900 dark:text-red-100",
+};
+
+const [badgeVariant, resolveBadgeVariantProps] = vcn({
+  base: "inline-flex w-fit items-center rounded-md border font-medium leading-none",
+  variants: {
+    size: {
+      sm: "px-1.5 py-0.5 text-xs",
+      md: "px-2 py-1 text-sm",
+    },
+    status: {
+      default: badgeColors.default,
+      success: badgeColors.success,
+      warning: badgeColors.warning,
+      danger: badgeColors.danger,
+    },
+  },
+  defaults: {
+    size: "md",
+    status: "default",
+  },
+});
+
+interface BadgeProps
+  extends Omit<React.ComponentPropsWithoutRef<"span">, "className">,
+    VariantProps<typeof badgeVariant>,
+    AsChild {}
+
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>((props, ref) => {
+  const [variantProps, otherPropsCompressed] = resolveBadgeVariantProps(props);
+  const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      ref={ref}
+      className={badgeVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+Badge.displayName = "Badge";
+
+export { Badge };

--- a/src/pswui/components/Breadcrumb.tsx
+++ b/src/pswui/components/Breadcrumb.tsx
@@ -1,0 +1,189 @@
+import { type AsChild, Slot, type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [breadcrumbVariant, resolveBreadcrumbVariantProps] = vcn({
+  base: "w-full",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbProps
+  extends VariantProps<typeof breadcrumbVariant>,
+    React.ComponentPropsWithoutRef<"nav"> {}
+
+const Breadcrumb = React.forwardRef<HTMLElement, BreadcrumbProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveBreadcrumbVariantProps(props);
+    const { "aria-label": ariaLabel, ...otherPropsExtracted } =
+      otherPropsCompressed;
+
+    return (
+      <nav
+        ref={ref}
+        aria-label={ariaLabel ?? "Breadcrumb"}
+        className={breadcrumbVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+Breadcrumb.displayName = "Breadcrumb";
+
+const [breadcrumbListVariant, resolveBreadcrumbListVariantProps] = vcn({
+  base: "flex flex-wrap items-center gap-1.5 text-sm text-neutral-500 dark:text-neutral-400",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbListProps
+  extends VariantProps<typeof breadcrumbListVariant>,
+    React.ComponentPropsWithoutRef<"ol"> {}
+
+const BreadcrumbList = React.forwardRef<HTMLOListElement, BreadcrumbListProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveBreadcrumbListVariantProps(props);
+
+    return (
+      <ol
+        ref={ref}
+        className={breadcrumbListVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+BreadcrumbList.displayName = "BreadcrumbList";
+
+const [breadcrumbItemVariant, resolveBreadcrumbItemVariantProps] = vcn({
+  base: "inline-flex items-center gap-1.5",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbItemProps
+  extends VariantProps<typeof breadcrumbItemVariant>,
+    React.ComponentPropsWithoutRef<"li"> {}
+
+const BreadcrumbItem = React.forwardRef<HTMLLIElement, BreadcrumbItemProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveBreadcrumbItemVariantProps(props);
+
+    return (
+      <li
+        ref={ref}
+        className={breadcrumbItemVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+BreadcrumbItem.displayName = "BreadcrumbItem";
+
+const [breadcrumbLinkVariant, resolveBreadcrumbLinkVariantProps] = vcn({
+  base: "transition-colors hover:text-neutral-950 focus-visible:text-neutral-950 focus-visible:underline focus-visible:outline-none dark:hover:text-neutral-50 dark:focus-visible:text-neutral-50",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbLinkProps
+  extends VariantProps<typeof breadcrumbLinkVariant>,
+    Omit<React.ComponentPropsWithoutRef<"a">, "className">,
+    AsChild {}
+
+const BreadcrumbLink = React.forwardRef<HTMLAnchorElement, BreadcrumbLinkProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveBreadcrumbLinkVariantProps(props);
+    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "a";
+
+    return (
+      <Comp
+        ref={ref}
+        className={breadcrumbLinkVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+BreadcrumbLink.displayName = "BreadcrumbLink";
+
+const [breadcrumbPageVariant, resolveBreadcrumbPageVariantProps] = vcn({
+  base: "font-medium text-neutral-950 dark:text-neutral-50",
+  variants: {},
+  defaults: {},
+});
+
+interface BreadcrumbPageProps
+  extends VariantProps<typeof breadcrumbPageVariant>,
+    Omit<React.ComponentPropsWithoutRef<"span">, "className">,
+    AsChild {}
+
+const BreadcrumbPage = React.forwardRef<HTMLElement, BreadcrumbPageProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveBreadcrumbPageVariantProps(props);
+    const {
+      asChild,
+      "aria-current": ariaCurrent,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "span";
+
+    return (
+      <Comp
+        ref={ref}
+        aria-current={ariaCurrent ?? "page"}
+        className={breadcrumbPageVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+BreadcrumbPage.displayName = "BreadcrumbPage";
+
+const [breadcrumbSeparatorVariant, resolveBreadcrumbSeparatorVariantProps] =
+  vcn({
+    base: "inline-flex items-center text-neutral-400 dark:text-neutral-600",
+    variants: {},
+    defaults: {},
+  });
+
+interface BreadcrumbSeparatorProps
+  extends VariantProps<typeof breadcrumbSeparatorVariant>,
+    Omit<React.ComponentPropsWithoutRef<"li">, "className"> {}
+
+const BreadcrumbSeparator = React.forwardRef<
+  HTMLLIElement,
+  BreadcrumbSeparatorProps
+>((props, ref) => {
+  const [variantProps, otherPropsExtracted] =
+    resolveBreadcrumbSeparatorVariantProps(props);
+
+  return (
+    <li
+      ref={ref}
+      role="presentation"
+      aria-hidden="true"
+      className={breadcrumbSeparatorVariant(variantProps)}
+      {...otherPropsExtracted}
+    >
+      {props.children ?? "/"}
+    </li>
+  );
+});
+BreadcrumbSeparator.displayName = "BreadcrumbSeparator";
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+};

--- a/src/pswui/components/Card.tsx
+++ b/src/pswui/components/Card.tsx
@@ -1,0 +1,189 @@
+import { type AsChild, Slot, type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [cardVariant, resolveCardVariantProps] = vcn({
+  base: "flex flex-col gap-4 rounded-lg border border-neutral-200 bg-white p-6 text-neutral-950 shadow-sm dark:border-neutral-800 dark:bg-black dark:text-neutral-50",
+  variants: {},
+  defaults: {},
+});
+
+interface CardProps
+  extends VariantProps<typeof cardVariant>,
+    React.ComponentPropsWithoutRef<"article">,
+    AsChild {}
+
+const Card = React.forwardRef<HTMLElement, CardProps>((props, ref) => {
+  const [variantProps, otherPropsCompressed] = resolveCardVariantProps(props);
+  const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+  const Comp = asChild ? Slot : "article";
+
+  return (
+    <Comp
+      ref={ref}
+      className={cardVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+Card.displayName = "Card";
+
+const [cardHeaderVariant, resolveCardHeaderVariantProps] = vcn({
+  base: "flex flex-col gap-1.5",
+  variants: {},
+  defaults: {},
+});
+
+interface CardHeaderProps
+  extends VariantProps<typeof cardHeaderVariant>,
+    React.ComponentPropsWithoutRef<"header">,
+    AsChild {}
+
+const CardHeader = React.forwardRef<HTMLElement, CardHeaderProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveCardHeaderVariantProps(props);
+    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "header";
+
+    return (
+      <Comp
+        ref={ref}
+        className={cardHeaderVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+CardHeader.displayName = "CardHeader";
+
+const [cardTitleVariant, resolveCardTitleVariantProps] = vcn({
+  base: "text-xl font-semibold leading-none",
+  variants: {},
+  defaults: {},
+});
+
+interface CardTitleProps
+  extends VariantProps<typeof cardTitleVariant>,
+    React.ComponentPropsWithoutRef<"h3">,
+    AsChild {}
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, CardTitleProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveCardTitleVariantProps(props);
+    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "h3";
+
+    return (
+      <Comp
+        ref={ref}
+        className={cardTitleVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+CardTitle.displayName = "CardTitle";
+
+const [cardDescriptionVariant, resolveCardDescriptionVariantProps] = vcn({
+  base: "text-sm text-neutral-500 dark:text-neutral-400",
+  variants: {},
+  defaults: {},
+});
+
+interface CardDescriptionProps
+  extends VariantProps<typeof cardDescriptionVariant>,
+    React.ComponentPropsWithoutRef<"p">,
+    AsChild {}
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  CardDescriptionProps
+>((props, ref) => {
+  const [variantProps, otherPropsCompressed] =
+    resolveCardDescriptionVariantProps(props);
+  const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+  const Comp = asChild ? Slot : "p";
+
+  return (
+    <Comp
+      ref={ref}
+      className={cardDescriptionVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+CardDescription.displayName = "CardDescription";
+
+const [cardContentVariant, resolveCardContentVariantProps] = vcn({
+  base: "flex flex-col gap-2",
+  variants: {},
+  defaults: {},
+});
+
+interface CardContentProps
+  extends VariantProps<typeof cardContentVariant>,
+    React.ComponentPropsWithoutRef<"div">,
+    AsChild {}
+
+const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveCardContentVariantProps(props);
+    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "div";
+
+    return (
+      <Comp
+        ref={ref}
+        className={cardContentVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+CardContent.displayName = "CardContent";
+
+const [cardFooterVariant, resolveCardFooterVariantProps] = vcn({
+  base: "flex flex-row items-center gap-2",
+  variants: {},
+  defaults: {},
+});
+
+interface CardFooterProps
+  extends VariantProps<typeof cardFooterVariant>,
+    React.ComponentPropsWithoutRef<"footer">,
+    AsChild {}
+
+const CardFooter = React.forwardRef<HTMLElement, CardFooterProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveCardFooterVariantProps(props);
+    const { asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "footer";
+
+    return (
+      <Comp
+        ref={ref}
+        className={cardFooterVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+CardFooter.displayName = "CardFooter";
+
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+};

--- a/src/pswui/components/Pagination.tsx
+++ b/src/pswui/components/Pagination.tsx
@@ -1,0 +1,241 @@
+import { type AsChild, Slot, vcn } from "@pswui-lib";
+import React from "react";
+
+const paginationColors = {
+  border: "border-neutral-300 dark:border-neutral-700",
+  background: {
+    default: "bg-white dark:bg-black",
+    hover: "hover:bg-neutral-100 dark:hover:bg-neutral-900",
+    active:
+      "bg-neutral-900 text-white dark:bg-neutral-100 dark:text-neutral-900",
+  },
+  text: "text-neutral-700 dark:text-neutral-200",
+  muted: "text-neutral-500 dark:text-neutral-400",
+  outline: "focus-visible:outline-black/10 dark:focus-visible:outline-white/20",
+};
+
+const [paginationLinkVariants] = vcn({
+  base: `inline-flex min-h-9 min-w-9 items-center justify-center gap-1 rounded-md border px-3 text-sm font-medium outline outline-1 outline-transparent outline-offset-2 transition-colors ${paginationColors.outline}`,
+  variants: {
+    current: {
+      true: `border-transparent ${paginationColors.background.active}`,
+      false: `${paginationColors.border} ${paginationColors.background.default} ${paginationColors.background.hover} ${paginationColors.text}`,
+    },
+    disabledStyle: {
+      true: "cursor-not-allowed opacity-50",
+      false: "cursor-pointer",
+    },
+  },
+  defaults: {
+    current: false,
+    disabledStyle: false,
+  },
+});
+
+interface PaginationProps
+  extends React.ComponentPropsWithoutRef<"nav">,
+    AsChild {}
+
+const Pagination = React.forwardRef<HTMLElement, PaginationProps>(
+  (props, ref) => {
+    const {
+      asChild,
+      className,
+      "aria-label": ariaLabel,
+      ...otherProps
+    } = props;
+    const Comp = asChild ? Slot : "nav";
+
+    return (
+      <Comp
+        ref={ref}
+        aria-label={ariaLabel ?? "Pagination"}
+        className={`flex w-full justify-center ${className ?? ""}`.trim()}
+        {...otherProps}
+      />
+    );
+  },
+);
+Pagination.displayName = "Pagination";
+
+interface PaginationContentProps
+  extends React.ComponentPropsWithoutRef<"ul">,
+    AsChild {}
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  PaginationContentProps
+>((props, ref) => {
+  const { asChild, className, ...otherProps } = props;
+  const Comp = asChild ? Slot : "ul";
+
+  return (
+    <Comp
+      ref={ref}
+      className={`m-0 flex flex-wrap items-center gap-1 p-0 list-none ${className ?? ""}`.trim()}
+      {...otherProps}
+    />
+  );
+});
+PaginationContent.displayName = "PaginationContent";
+
+interface PaginationItemProps
+  extends React.ComponentPropsWithoutRef<"li">,
+    AsChild {}
+
+const PaginationItem = React.forwardRef<HTMLLIElement, PaginationItemProps>(
+  (props, ref) => {
+    const { asChild, className, ...otherProps } = props;
+    const Comp = asChild ? Slot : "li";
+
+    return (
+      <Comp
+        ref={ref}
+        className={className}
+        {...otherProps}
+      />
+    );
+  },
+);
+PaginationItem.displayName = "PaginationItem";
+
+interface PaginationLinkProps
+  extends React.ComponentPropsWithoutRef<"a">,
+    AsChild {
+  active?: boolean;
+  disabled?: boolean;
+}
+
+const PaginationLink = React.forwardRef<HTMLAnchorElement, PaginationLinkProps>(
+  (props, ref) => {
+    const {
+      asChild,
+      children,
+      className,
+      active,
+      disabled,
+      href,
+      onClick,
+      role,
+      tabIndex,
+      "aria-current": ariaCurrent,
+      "aria-disabled": ariaDisabled,
+      ...otherProps
+    } = props;
+    const Comp = asChild ? Slot : "a";
+
+    return (
+      <Comp
+        ref={ref}
+        href={disabled ? undefined : href}
+        role={role ?? "link"}
+        aria-current={active ? ariaCurrent ?? "page" : ariaCurrent}
+        aria-disabled={disabled ? true : ariaDisabled}
+        tabIndex={disabled ? -1 : tabIndex}
+        className={paginationLinkVariants({
+          current: active,
+          disabledStyle: disabled,
+          className,
+        })}
+        onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+          if (disabled) {
+            event.preventDefault();
+            return;
+          }
+
+          onClick?.(event);
+        }}
+        {...otherProps}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+PaginationLink.displayName = "PaginationLink";
+
+interface PaginationPreviousProps
+  extends Omit<PaginationLinkProps, "children"> {
+  children?: React.ReactNode;
+}
+
+const PaginationPrevious = React.forwardRef<
+  HTMLAnchorElement,
+  PaginationPreviousProps
+>((props, ref) => {
+  const { children, "aria-label": ariaLabel, ...otherProps } = props;
+
+  return (
+    <PaginationLink
+      ref={ref}
+      aria-label={ariaLabel ?? "Previous page"}
+      {...otherProps}
+    >
+      <span aria-hidden="true">&lt;</span>
+      <span>{children ?? "Previous"}</span>
+    </PaginationLink>
+  );
+});
+PaginationPrevious.displayName = "PaginationPrevious";
+
+interface PaginationNextProps extends Omit<PaginationLinkProps, "children"> {
+  children?: React.ReactNode;
+}
+
+const PaginationNext = React.forwardRef<HTMLAnchorElement, PaginationNextProps>(
+  (props, ref) => {
+    const { children, "aria-label": ariaLabel, ...otherProps } = props;
+
+    return (
+      <PaginationLink
+        ref={ref}
+        aria-label={ariaLabel ?? "Next page"}
+        {...otherProps}
+      >
+        <span>{children ?? "Next"}</span>
+        <span aria-hidden="true">&gt;</span>
+      </PaginationLink>
+    );
+  },
+);
+PaginationNext.displayName = "PaginationNext";
+
+interface PaginationEllipsisProps
+  extends React.ComponentPropsWithoutRef<"span">,
+    AsChild {}
+
+const PaginationEllipsis = React.forwardRef<
+  HTMLSpanElement,
+  PaginationEllipsisProps
+>((props, ref) => {
+  const {
+    asChild,
+    className,
+    "aria-hidden": ariaHidden,
+    children,
+    ...otherProps
+  } = props;
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      ref={ref}
+      aria-hidden={ariaHidden ?? true}
+      className={`inline-flex min-h-9 min-w-9 items-center justify-center text-sm ${paginationColors.muted} ${className ?? ""}`.trim()}
+      {...otherProps}
+    >
+      {children ?? "..."}
+    </Comp>
+  );
+});
+PaginationEllipsis.displayName = "PaginationEllipsis";
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+};

--- a/src/pswui/components/Progress.tsx
+++ b/src/pswui/components/Progress.tsx
@@ -1,0 +1,53 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [progressVariant, resolveProgressVariantProps] = vcn({
+  base: "h-2 w-full overflow-hidden rounded-md border-0 bg-neutral-200 dark:bg-neutral-800 [&::-moz-progress-bar]:bg-neutral-900 [&::-webkit-progress-bar]:bg-transparent [&::-webkit-progress-value]:bg-neutral-900 dark:[&::-moz-progress-bar]:bg-neutral-100 dark:[&::-webkit-progress-value]:bg-neutral-100",
+  variants: {
+    size: {
+      sm: "h-1",
+      md: "h-2",
+      lg: "h-3",
+    },
+  },
+  defaults: {
+    size: "md",
+  },
+});
+
+interface ProgressProps
+  extends VariantProps<typeof progressVariant>,
+    Omit<React.ComponentPropsWithoutRef<"progress">, "max" | "value"> {
+  max?: number;
+  value?: number | null;
+}
+
+const Progress = React.forwardRef<HTMLProgressElement, ProgressProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveProgressVariantProps(props);
+    const { max = 100, value, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const resolvedMax = Number.isFinite(max) && max > 0 ? max : 100;
+    const isDeterminate = typeof value === "number" && Number.isFinite(value);
+    const resolvedValue = isDeterminate
+      ? Math.min(Math.max(value, 0), resolvedMax)
+      : undefined;
+
+    return (
+      <progress
+        {...otherPropsExtracted}
+        ref={ref}
+        max={resolvedMax}
+        value={resolvedValue}
+        aria-valuemin={0}
+        aria-valuemax={resolvedMax}
+        aria-valuenow={resolvedValue}
+        className={progressVariant(variantProps)}
+      />
+    );
+  },
+);
+Progress.displayName = "Progress";
+
+export { Progress };

--- a/src/pswui/components/RadioGroup.tsx
+++ b/src/pswui/components/RadioGroup.tsx
@@ -1,0 +1,162 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [radioGroupVariant, resolveRadioGroupVariantProps] = vcn({
+  base: "flex",
+  variants: {
+    orientation: {
+      vertical: "flex-col items-start gap-3",
+      horizontal: "flex-row flex-wrap items-center gap-4",
+    },
+  },
+  defaults: {
+    orientation: "vertical",
+  },
+});
+
+const [radioGroupItemVariant, resolveRadioGroupItemVariantProps] = vcn({
+  base: "relative inline-flex w-fit items-center gap-3 rounded-md text-sm outline outline-2 outline-offset-2 outline-transparent transition-colors duration-150 has-[input:focus-visible]:outline-black/10 dark:has-[input:focus-visible]:outline-white/20 has-[input:disabled]:cursor-not-allowed has-[input:disabled]:opacity-60",
+  variants: {},
+  defaults: {},
+});
+
+interface RadioGroupContextValue {
+  disabled?: boolean;
+  name: string;
+  setValue: (value: string) => void;
+  value?: string;
+}
+
+const RadioGroupContext = React.createContext<RadioGroupContextValue | null>(
+  null,
+);
+
+const useRadioGroupContext = () => {
+  const context = React.useContext(RadioGroupContext);
+
+  if (!context) {
+    throw new Error("RadioGroupItem must be used within RadioGroup.");
+  }
+
+  return context;
+};
+
+interface RadioGroupProps
+  extends VariantProps<typeof radioGroupVariant>,
+    Omit<
+      React.ComponentPropsWithoutRef<"div">,
+      "children" | "className" | "defaultValue" | "onChange"
+    > {
+  children?: React.ReactNode;
+  defaultValue?: string;
+  disabled?: boolean;
+  name?: string;
+  onValueChange?: (value: string) => void;
+  value?: string;
+}
+
+const RadioGroup = React.forwardRef<HTMLDivElement, RadioGroupProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveRadioGroupVariantProps(props);
+    const {
+      children,
+      defaultValue,
+      disabled,
+      name,
+      onValueChange,
+      value: propValue,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const generatedName = React.useId();
+    const resolvedName = name ?? generatedName;
+    const [uncontrolledValue, setUncontrolledValue] =
+      React.useState(defaultValue);
+    const isControlled = typeof propValue === "string";
+    const value = isControlled ? propValue : uncontrolledValue;
+
+    const orientation = variantProps.orientation ?? "vertical";
+    const contextValue = {
+      disabled,
+      name: resolvedName,
+      setValue: (nextValue: string) => {
+        if (!isControlled) {
+          setUncontrolledValue(nextValue);
+        }
+
+        onValueChange?.(nextValue);
+      },
+      value,
+    };
+
+    return (
+      <RadioGroupContext.Provider value={contextValue}>
+        <div
+          {...otherPropsExtracted}
+          ref={ref}
+          role="radiogroup"
+          aria-disabled={disabled ? true : undefined}
+          aria-orientation={orientation}
+          className={radioGroupVariant(variantProps)}
+        >
+          {children}
+        </div>
+      </RadioGroupContext.Provider>
+    );
+  },
+);
+RadioGroup.displayName = "RadioGroup";
+
+interface RadioGroupItemProps
+  extends VariantProps<typeof radioGroupItemVariant>,
+    Omit<
+      React.ComponentPropsWithoutRef<"input">,
+      "checked" | "className" | "defaultChecked" | "name" | "size" | "type"
+    > {
+  children?: React.ReactNode;
+  value: string;
+}
+
+const RadioGroupItem = React.forwardRef<HTMLInputElement, RadioGroupItemProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveRadioGroupItemVariantProps(props);
+    const { children, disabled, onChange, value, ...otherPropsExtracted } =
+      otherPropsCompressed;
+
+    const group = useRadioGroupContext();
+    const isDisabled = group.disabled || disabled;
+    const isChecked = group.value === value;
+
+    return (
+      <label className={radioGroupItemVariant(variantProps)}>
+        <input
+          {...otherPropsExtracted}
+          ref={ref}
+          type="radio"
+          name={group.name}
+          value={value}
+          checked={isChecked}
+          disabled={isDisabled}
+          className="peer absolute inset-0 z-10 m-0 h-full w-full cursor-inherit opacity-0 disabled:cursor-not-allowed"
+          onChange={(event) => {
+            if (event.currentTarget.checked) {
+              group.setValue(value);
+            }
+
+            onChange?.(event);
+          }}
+        />
+        <span
+          aria-hidden
+          className="inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-neutral-400 bg-white text-white transition-colors duration-150 after:block after:size-2 after:scale-0 after:rounded-full after:bg-current after:transition-transform after:duration-150 after:content-[''] peer-checked:border-neutral-900 peer-checked:bg-neutral-900 peer-checked:after:scale-100 peer-disabled:border-neutral-300 peer-disabled:bg-neutral-100 dark:border-neutral-600 dark:bg-black dark:text-black dark:peer-checked:border-white dark:peer-checked:bg-white dark:peer-disabled:border-neutral-700 dark:peer-disabled:bg-neutral-900"
+        />
+        {children ? <span>{children}</span> : null}
+      </label>
+    );
+  },
+);
+RadioGroupItem.displayName = "RadioGroupItem";
+
+export { RadioGroup, RadioGroupItem };

--- a/src/pswui/components/ScrollArea.tsx
+++ b/src/pswui/components/ScrollArea.tsx
@@ -1,0 +1,43 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [scrollAreaVariant, resolveScrollAreaVariantProps] = vcn({
+  base: "relative overscroll-contain focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-300 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-neutral-700 dark:focus-visible:ring-offset-black [scrollbar-width:thin] [&::-webkit-scrollbar]:h-2.5 [&::-webkit-scrollbar]:w-2.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-neutral-300 dark:[&::-webkit-scrollbar-thumb]:bg-neutral-700",
+  variants: {
+    orientation: {
+      vertical: "overflow-y-auto overflow-x-hidden",
+      horizontal: "overflow-x-auto overflow-y-hidden",
+      both: "overflow-auto",
+    },
+  },
+  defaults: {
+    orientation: "vertical",
+  },
+});
+
+interface ScrollAreaProps
+  extends VariantProps<typeof scrollAreaVariant>,
+    React.ComponentPropsWithoutRef<"div"> {}
+
+const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveScrollAreaVariantProps(props);
+    const { tabIndex, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const orientation = variantProps.orientation ?? "vertical";
+
+    return (
+      <div
+        ref={ref}
+        data-orientation={orientation}
+        tabIndex={tabIndex ?? 0}
+        className={scrollAreaVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+ScrollArea.displayName = "ScrollArea";
+
+export { ScrollArea };

--- a/src/pswui/components/Select.tsx
+++ b/src/pswui/components/Select.tsx
@@ -1,0 +1,424 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [selectTriggerVariant, resolveSelectTriggerVariantProps] = vcn({
+  base: "group/select inline-flex min-h-10 items-center justify-between gap-3 rounded-md border border-neutral-400 bg-neutral-50 px-3 py-2 text-left text-sm ring-1 ring-transparent outline-hidden transition-all duration-200 hover:bg-neutral-100 focus-visible:ring-current disabled:cursor-not-allowed disabled:brightness-50 disabled:saturate-0 dark:border-neutral-600 dark:bg-neutral-900 dark:hover:bg-neutral-800",
+  variants: {
+    full: {
+      true: "w-full",
+      false: "min-w-56 w-fit",
+    },
+  },
+  defaults: {
+    full: false,
+  },
+});
+
+const [selectContentVariant] = vcn({
+  base: "absolute left-0 top-[calc(100%+0.375rem)] z-20 w-full overflow-hidden rounded-md border border-neutral-200 bg-white p-1 shadow-lg transition-all duration-150 dark:border-neutral-800 dark:bg-black",
+  variants: {
+    opened: {
+      true: "visible translate-y-0 opacity-100",
+      false: "invisible -translate-y-1 opacity-0 pointer-events-none",
+    },
+  },
+  defaults: {
+    opened: false,
+  },
+});
+
+interface SelectOption {
+  disabled?: boolean;
+  label: React.ReactNode;
+  value: string;
+}
+
+const getFirstEnabledIndex = (options: SelectOption[]) =>
+  options.findIndex((option) => !option.disabled);
+
+const getLastEnabledIndex = (options: SelectOption[]) => {
+  for (let index = options.length - 1; index >= 0; index -= 1) {
+    if (!options[index]?.disabled) {
+      return index;
+    }
+  }
+
+  return -1;
+};
+
+const getNextEnabledIndex = (
+  options: SelectOption[],
+  currentIndex: number,
+  direction: 1 | -1,
+) => {
+  for (
+    let index = currentIndex + direction;
+    index >= 0 && index < options.length;
+    index += direction
+  ) {
+    if (!options[index]?.disabled) {
+      return index;
+    }
+  }
+
+  return -1;
+};
+
+export interface SelectProps
+  extends VariantProps<typeof selectTriggerVariant>,
+    Omit<
+      React.ComponentPropsWithoutRef<"button">,
+      "children" | "defaultValue" | "name" | "onChange" | "type" | "value"
+    > {
+  defaultValue?: string;
+  name?: string;
+  onValueChange?: (value: string) => void;
+  options: SelectOption[];
+  placeholder?: React.ReactNode;
+  value?: string;
+}
+
+const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveSelectTriggerVariantProps(props);
+    const {
+      defaultValue,
+      disabled,
+      id,
+      name,
+      onClick,
+      onKeyDown,
+      onValueChange,
+      options,
+      placeholder = "Select an option",
+      value: propValue,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const generatedId = React.useId();
+    const buttonId = id ?? generatedId;
+    const listboxId = `${buttonId}-listbox`;
+    const isControlled = propValue !== undefined;
+    const [uncontrolledValue, setUncontrolledValue] =
+      React.useState(defaultValue);
+    const [opened, setOpened] = React.useState(false);
+    const buttonRef = React.useRef<HTMLButtonElement | null>(null);
+    const listboxRef = React.useRef<HTMLDivElement | null>(null);
+    const rootRef = React.useRef<HTMLDivElement | null>(null);
+
+    const value = isControlled ? propValue : uncontrolledValue;
+    const selectedIndex = options.findIndex((option) => option.value === value);
+    const selectedOption = selectedIndex >= 0 ? options[selectedIndex] : null;
+    const firstEnabledIndex = getFirstEnabledIndex(options);
+    const lastEnabledIndex = getLastEnabledIndex(options);
+    const [highlightedIndex, setHighlightedIndex] = React.useState(() =>
+      selectedIndex >= 0 ? selectedIndex : firstEnabledIndex,
+    );
+
+    React.useEffect(() => {
+      if (!opened) {
+        setHighlightedIndex(
+          selectedIndex >= 0 ? selectedIndex : getFirstEnabledIndex(options),
+        );
+      }
+    }, [opened, options, selectedIndex]);
+
+    React.useEffect(() => {
+      if (!opened) {
+        return;
+      }
+
+      listboxRef.current?.focus();
+
+      const handleOutsideMouseDown = (event: MouseEvent) => {
+        if (rootRef.current?.contains(event.target as Node)) {
+          return;
+        }
+
+        setOpened(false);
+      };
+
+      document.addEventListener("mousedown", handleOutsideMouseDown);
+
+      return () => {
+        document.removeEventListener("mousedown", handleOutsideMouseDown);
+      };
+    }, [opened]);
+
+    const setRefs = (element: HTMLButtonElement | null) => {
+      buttonRef.current = element;
+      if (typeof ref === "function") {
+        ref(element);
+      } else if (ref) {
+        ref.current = element;
+      }
+    };
+
+    const openSelect = (nextHighlightedIndex: number) => {
+      setHighlightedIndex(nextHighlightedIndex);
+      setOpened(true);
+    };
+
+    const closeSelect = () => {
+      setOpened(false);
+      buttonRef.current?.focus();
+    };
+
+    const commitValue = (nextValue: string) => {
+      if (!isControlled) {
+        setUncontrolledValue(nextValue);
+      }
+
+      onValueChange?.(nextValue);
+      closeSelect();
+    };
+
+    const moveHighlightedIndex = (direction: 1 | -1) => {
+      const nextIndex = getNextEnabledIndex(
+        options,
+        highlightedIndex,
+        direction,
+      );
+      if (nextIndex >= 0) {
+        setHighlightedIndex(nextIndex);
+      }
+    };
+
+    const resolvedFull = variantProps.full ?? false;
+    const activeDescendant =
+      highlightedIndex >= 0
+        ? `${buttonId}-option-${highlightedIndex}`
+        : undefined;
+
+    return (
+      <div
+        ref={rootRef}
+        data-state={opened ? "open" : "closed"}
+        className={`relative ${resolvedFull ? "w-full" : "w-fit"}`}
+      >
+        {name ? (
+          <input
+            type="hidden"
+            name={name}
+            value={selectedOption?.value ?? ""}
+            disabled={disabled}
+          />
+        ) : null}
+        <button
+          {...otherPropsExtracted}
+          ref={setRefs}
+          id={buttonId}
+          type="button"
+          disabled={disabled}
+          aria-controls={listboxId}
+          aria-expanded={opened}
+          aria-haspopup="listbox"
+          className={selectTriggerVariant(variantProps)}
+          onClick={(event) => {
+            onClick?.(event);
+
+            if (event.defaultPrevented || disabled) {
+              return;
+            }
+
+            if (opened) {
+              setOpened(false);
+              return;
+            }
+
+            openSelect(selectedIndex >= 0 ? selectedIndex : firstEnabledIndex);
+          }}
+          onKeyDown={(event) => {
+            onKeyDown?.(event);
+
+            if (event.defaultPrevented || disabled) {
+              return;
+            }
+
+            switch (event.key) {
+              case "ArrowDown":
+                event.preventDefault();
+                if (opened) {
+                  moveHighlightedIndex(1);
+                  break;
+                }
+                openSelect(
+                  selectedIndex >= 0
+                    ? selectedIndex
+                    : getFirstEnabledIndex(options),
+                );
+                break;
+              case "ArrowUp":
+                event.preventDefault();
+                if (opened) {
+                  moveHighlightedIndex(-1);
+                  break;
+                }
+                openSelect(
+                  selectedIndex >= 0
+                    ? selectedIndex
+                    : getLastEnabledIndex(options),
+                );
+                break;
+              case "Home":
+                event.preventDefault();
+                if (opened) {
+                  setHighlightedIndex(firstEnabledIndex);
+                  break;
+                }
+                openSelect(firstEnabledIndex);
+                break;
+              case "End":
+                event.preventDefault();
+                if (opened) {
+                  setHighlightedIndex(lastEnabledIndex);
+                  break;
+                }
+                openSelect(lastEnabledIndex);
+                break;
+              case "Enter":
+              case " ":
+                if (!opened) {
+                  break;
+                }
+                event.preventDefault();
+                if (
+                  highlightedIndex >= 0 &&
+                  options[highlightedIndex] &&
+                  !options[highlightedIndex]?.disabled
+                ) {
+                  commitValue(options[highlightedIndex].value);
+                }
+                break;
+              case "Escape":
+                if (!opened) {
+                  break;
+                }
+                event.preventDefault();
+                closeSelect();
+                break;
+            }
+          }}
+        >
+          <span className={selectedOption ? "" : "opacity-60"}>
+            {selectedOption?.label ?? placeholder}
+          </span>
+          <span
+            aria-hidden
+            className={`size-4 shrink-0 opacity-60 transition-transform duration-150 ${
+              opened ? "rotate-180" : ""
+            }`}
+          >
+            v
+          </span>
+        </button>
+        <div
+          className={selectContentVariant({ opened })}
+          aria-hidden={opened ? undefined : true}
+        >
+          <div
+            ref={listboxRef}
+            id={listboxId}
+            role="listbox"
+            tabIndex={-1}
+            aria-activedescendant={activeDescendant}
+            aria-labelledby={buttonId}
+            className="max-h-60 overflow-y-auto outline-hidden"
+            onKeyDown={(event) => {
+              switch (event.key) {
+                case "ArrowDown": {
+                  event.preventDefault();
+                  moveHighlightedIndex(1);
+                  break;
+                }
+                case "ArrowUp": {
+                  event.preventDefault();
+                  moveHighlightedIndex(-1);
+                  break;
+                }
+                case "Home":
+                  event.preventDefault();
+                  setHighlightedIndex(firstEnabledIndex);
+                  break;
+                case "End":
+                  event.preventDefault();
+                  setHighlightedIndex(lastEnabledIndex);
+                  break;
+                case "Enter":
+                case " ": {
+                  event.preventDefault();
+                  const option = options[highlightedIndex];
+                  if (option && !option.disabled) {
+                    commitValue(option.value);
+                  }
+                  break;
+                }
+                case "Escape":
+                  event.preventDefault();
+                  closeSelect();
+                  break;
+                case "Tab":
+                  setOpened(false);
+                  break;
+              }
+            }}
+          >
+            {options.map((option, index) => {
+              const isHighlighted = index === highlightedIndex;
+              const isSelected = option.value === selectedOption?.value;
+
+              return (
+                <div
+                  key={option.value}
+                  id={`${buttonId}-option-${index}`}
+                  role="option"
+                  aria-disabled={option.disabled ? true : undefined}
+                  aria-selected={isSelected}
+                  tabIndex={-1}
+                  data-highlighted={isHighlighted ? "" : undefined}
+                  data-selected={isSelected ? "" : undefined}
+                  className={`flex cursor-pointer items-center rounded-md px-3 py-2 text-sm transition-colors duration-150 ${
+                    option.disabled
+                      ? "cursor-not-allowed opacity-50"
+                      : "hover:bg-neutral-100 dark:hover:bg-neutral-900"
+                  } ${
+                    isHighlighted ? "bg-neutral-100 dark:bg-neutral-900" : ""
+                  } ${
+                    isSelected
+                      ? "font-medium text-neutral-950 dark:text-neutral-50"
+                      : ""
+                  }`}
+                  onMouseMove={() => {
+                    if (!option.disabled) {
+                      setHighlightedIndex(index);
+                    }
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      if (!option.disabled) {
+                        commitValue(option.value);
+                      }
+                    }
+                  }}
+                  onClick={() => {
+                    if (!option.disabled) {
+                      commitValue(option.value);
+                    }
+                  }}
+                >
+                  {option.label}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+Select.displayName = "Select";
+
+export type { SelectOption };
+export { Select };

--- a/src/pswui/components/Separator.tsx
+++ b/src/pswui/components/Separator.tsx
@@ -1,0 +1,55 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [separatorVariant, resolveSeparatorVariantProps] = vcn({
+  base: "shrink-0 bg-neutral-200 dark:bg-neutral-800",
+  variants: {
+    orientation: {
+      horizontal: "h-px w-full",
+      vertical: "h-full w-px self-stretch",
+    },
+  },
+  defaults: {
+    orientation: "horizontal",
+  },
+});
+
+interface SeparatorProps
+  extends VariantProps<typeof separatorVariant>,
+    Omit<React.ComponentPropsWithoutRef<"div">, "className"> {
+  decorative?: boolean;
+}
+
+const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveSeparatorVariantProps(props);
+    const {
+      decorative,
+      role,
+      "aria-hidden": ariaHidden,
+      "aria-orientation": ariaOrientation,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const orientation = variantProps.orientation ?? "horizontal";
+    const ariaOrientationValue =
+      orientation === "vertical"
+        ? ariaOrientation ?? "vertical"
+        : ariaOrientation;
+
+    return (
+      <div
+        ref={ref}
+        role={decorative ? "none" : role ?? "separator"}
+        aria-hidden={decorative ? true : ariaHidden}
+        aria-orientation={decorative ? undefined : ariaOrientationValue}
+        className={separatorVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+Separator.displayName = "Separator";
+
+export { Separator };

--- a/src/pswui/components/Skeleton.tsx
+++ b/src/pswui/components/Skeleton.tsx
@@ -1,0 +1,48 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [skeletonVariant, resolveSkeletonVariantProps] = vcn({
+  base: "block animate-pulse bg-neutral-200 dark:bg-neutral-800",
+  variants: {
+    shape: {
+      rectangle: "rounded-md",
+      circle: "rounded-full",
+      text: "rounded-md",
+    },
+    size: {
+      sm: "h-3 w-full",
+      md: "h-4 w-full",
+      lg: "h-6 w-full",
+      icon: "size-10",
+    },
+  },
+  defaults: {
+    shape: "rectangle",
+    size: "md",
+  },
+});
+
+interface SkeletonProps
+  extends VariantProps<typeof skeletonVariant>,
+    Omit<React.ComponentPropsWithoutRef<"div">, "className"> {}
+
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveSkeletonVariantProps(props);
+    const { "aria-hidden": ariaHidden, ...otherPropsExtracted } =
+      otherPropsCompressed;
+
+    return (
+      <div
+        ref={ref}
+        aria-hidden={ariaHidden ?? true}
+        className={skeletonVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+Skeleton.displayName = "Skeleton";
+
+export { Skeleton };

--- a/src/pswui/components/Slider.tsx
+++ b/src/pswui/components/Slider.tsx
@@ -1,0 +1,39 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [sliderVariants, resolveSliderVariantProps] = vcn({
+  base: "w-full cursor-pointer accent-neutral-900 disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black/20 dark:accent-neutral-100 dark:focus-visible:outline-white/30",
+  variants: {
+    size: {
+      sm: "h-3",
+      md: "h-4",
+      lg: "h-5",
+    },
+  },
+  defaults: {
+    size: "md",
+  },
+});
+
+interface SliderProps
+  extends VariantProps<typeof sliderVariants>,
+    Omit<
+      React.ComponentPropsWithoutRef<"input">,
+      "type" | "className" | "size"
+    > {}
+
+const Slider = React.forwardRef<HTMLInputElement, SliderProps>((props, ref) => {
+  const [variantProps, otherPropsExtracted] = resolveSliderVariantProps(props);
+
+  return (
+    <input
+      {...otherPropsExtracted}
+      ref={ref}
+      type="range"
+      className={sliderVariants(variantProps)}
+    />
+  );
+});
+Slider.displayName = "Slider";
+
+export { Slider };

--- a/src/pswui/components/Table.tsx
+++ b/src/pswui/components/Table.tsx
@@ -1,0 +1,219 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const [tableVariant, resolveTableVariantProps] = vcn({
+  base: "w-full caption-bottom text-sm",
+  variants: {},
+  defaults: {},
+});
+
+interface TableProps
+  extends VariantProps<typeof tableVariant>,
+    React.ComponentPropsWithoutRef<"table"> {}
+
+const Table = React.forwardRef<HTMLTableElement, TableProps>((props, ref) => {
+  const [variantProps, otherPropsExtracted] = resolveTableVariantProps(props);
+
+  return (
+    <table
+      ref={ref}
+      className={tableVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+Table.displayName = "Table";
+
+const [tableHeaderVariant, resolveTableHeaderVariantProps] = vcn({
+  base: "[&_tr]:border-b [&_tr]:border-neutral-200 dark:[&_tr]:border-neutral-800",
+  variants: {},
+  defaults: {},
+});
+
+interface TableHeaderProps
+  extends VariantProps<typeof tableHeaderVariant>,
+    React.ComponentPropsWithoutRef<"thead"> {}
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, TableHeaderProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableHeaderVariantProps(props);
+
+    return (
+      <thead
+        ref={ref}
+        className={tableHeaderVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableHeader.displayName = "TableHeader";
+
+const [tableBodyVariant, resolveTableBodyVariantProps] = vcn({
+  base: "[&_tr:last-child]:border-0",
+  variants: {},
+  defaults: {},
+});
+
+interface TableBodyProps
+  extends VariantProps<typeof tableBodyVariant>,
+    React.ComponentPropsWithoutRef<"tbody"> {}
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableBodyVariantProps(props);
+
+    return (
+      <tbody
+        ref={ref}
+        className={tableBodyVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableBody.displayName = "TableBody";
+
+const [tableFooterVariant, resolveTableFooterVariantProps] = vcn({
+  base: "border-t border-neutral-200 bg-neutral-50/50 font-medium dark:border-neutral-800 dark:bg-neutral-950/50 [&>tr]:last:border-b-0",
+  variants: {},
+  defaults: {},
+});
+
+interface TableFooterProps
+  extends VariantProps<typeof tableFooterVariant>,
+    React.ComponentPropsWithoutRef<"tfoot"> {}
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, TableFooterProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableFooterVariantProps(props);
+
+    return (
+      <tfoot
+        ref={ref}
+        className={tableFooterVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableFooter.displayName = "TableFooter";
+
+const [tableRowVariant, resolveTableRowVariantProps] = vcn({
+  base: "border-b border-neutral-200 transition-colors hover:bg-neutral-50/50 data-[state=selected]:bg-neutral-100 dark:border-neutral-800 dark:hover:bg-neutral-900/50 dark:data-[state=selected]:bg-neutral-900",
+  variants: {},
+  defaults: {},
+});
+
+interface TableRowProps
+  extends VariantProps<typeof tableRowVariant>,
+    React.ComponentPropsWithoutRef<"tr"> {}
+
+const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableRowVariantProps(props);
+
+    return (
+      <tr
+        ref={ref}
+        className={tableRowVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableRow.displayName = "TableRow";
+
+const [tableHeadVariant, resolveTableHeadVariantProps] = vcn({
+  base: "h-10 px-4 text-left align-middle font-medium text-neutral-500 dark:text-neutral-400 [&:has([role=checkbox])]:pr-0",
+  variants: {},
+  defaults: {},
+});
+
+interface TableHeadProps
+  extends VariantProps<typeof tableHeadVariant>,
+    React.ComponentPropsWithoutRef<"th"> {}
+
+const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableHeadVariantProps(props);
+
+    return (
+      <th
+        ref={ref}
+        className={tableHeadVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableHead.displayName = "TableHead";
+
+const [tableCellVariant, resolveTableCellVariantProps] = vcn({
+  base: "p-4 align-middle [&:has([role=checkbox])]:pr-0",
+  variants: {},
+  defaults: {},
+});
+
+interface TableCellProps
+  extends VariantProps<typeof tableCellVariant>,
+    React.ComponentPropsWithoutRef<"td"> {}
+
+const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsExtracted] =
+      resolveTableCellVariantProps(props);
+
+    return (
+      <td
+        ref={ref}
+        className={tableCellVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+TableCell.displayName = "TableCell";
+
+const [tableCaptionVariant, resolveTableCaptionVariantProps] = vcn({
+  base: "mt-4 text-sm text-neutral-500 dark:text-neutral-400",
+  variants: {},
+  defaults: {},
+});
+
+interface TableCaptionProps
+  extends VariantProps<typeof tableCaptionVariant>,
+    React.ComponentPropsWithoutRef<"caption"> {}
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  TableCaptionProps
+>((props, ref) => {
+  const [variantProps, otherPropsExtracted] =
+    resolveTableCaptionVariantProps(props);
+
+  return (
+    <caption
+      ref={ref}
+      className={tableCaptionVariant(variantProps)}
+      {...otherPropsExtracted}
+    />
+  );
+});
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+};

--- a/src/pswui/components/Textarea.tsx
+++ b/src/pswui/components/Textarea.tsx
@@ -1,0 +1,117 @@
+import { type AsChild, Slot, type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const textareaColors = {
+  background: {
+    default: "bg-neutral-50 dark:bg-neutral-900",
+    hover:
+      "hover:bg-neutral-100 dark:hover:bg-neutral-800 has-[textarea:hover]:bg-neutral-100 dark:has-[textarea:hover]:bg-neutral-800",
+    invalid:
+      "invalid:bg-red-100 dark:invalid:bg-red-900 has-[textarea:invalid]:bg-red-100 dark:has-[textarea:invalid]:bg-red-900",
+    invalidHover:
+      "hover:invalid:bg-red-200 dark:hover:invalid:bg-red-800 has-[textarea:invalid:hover]:bg-red-200 dark:has-[textarea:invalid:hover]:bg-red-800",
+  },
+  border: {
+    default: "border-neutral-400 dark:border-neutral-600",
+    invalid:
+      "invalid:border-red-400 dark:invalid:border-red-600 has-[textarea:invalid]:border-red-400 dark:has-[textarea:invalid]:border-red-600",
+  },
+  ring: {
+    default: "ring-transparent focus-within:ring-current",
+    invalid:
+      "invalid:focus-within:ring-red-400 dark:invalid:focus-within:ring-red-600 has-[textarea:invalid]:focus-within:ring-red-400 dark:has-[textarea:invalid]:focus-within:ring-red-600",
+  },
+};
+
+const [textareaVariant, resolveTextareaVariantProps] = vcn({
+  base: `rounded-md p-2 border ring-1 outline-hidden transition-all duration-200 disabled:brightness-50 disabled:saturate-0 disabled:cursor-not-allowed ${textareaColors.background.default} ${textareaColors.background.hover} ${textareaColors.border.default} ${textareaColors.ring.default} ${textareaColors.background.invalid} ${textareaColors.background.invalidHover} ${textareaColors.border.invalid} ${textareaColors.ring.invalid} [&:has(textarea)]:flex`,
+  variants: {
+    unstyled: {
+      true: "bg-transparent border-none p-0 ring-0 hover:bg-transparent invalid:hover:bg-transparent invalid:focus-within:bg-transparent invalid:focus-within:ring-0",
+      false: "",
+    },
+    full: {
+      true: "[&:has(textarea)]:w-full w-full",
+      false: "[&:has(textarea)]:w-fit w-fit",
+    },
+  },
+  defaults: {
+    unstyled: false,
+    full: false,
+  },
+});
+
+interface TextareaFrameProps
+  extends VariantProps<typeof textareaVariant>,
+    React.ComponentPropsWithoutRef<"label">,
+    AsChild {
+  children?: React.ReactNode;
+}
+
+const TextareaFrame = React.forwardRef<HTMLLabelElement, TextareaFrameProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveTextareaVariantProps(props);
+    const { children, asChild, ...otherPropsExtracted } = otherPropsCompressed;
+
+    const Comp = asChild ? Slot : "label";
+
+    return (
+      <Comp
+        ref={ref}
+        className={`group/textarea-frame ${textareaVariant(variantProps)}`}
+        {...otherPropsExtracted}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+TextareaFrame.displayName = "TextareaFrame";
+
+interface TextareaProps
+  extends VariantProps<typeof textareaVariant>,
+    React.ComponentPropsWithoutRef<"textarea"> {
+  invalid?: string;
+}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveTextareaVariantProps(props);
+    const {
+      invalid,
+      "aria-invalid": ariaInvalid,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+    const isInvalid = Boolean(invalid);
+    const resolvedAriaInvalid = isInvalid ? true : ariaInvalid;
+
+    const innerRef = React.useRef<HTMLTextAreaElement | null>(null);
+
+    React.useEffect(() => {
+      if (innerRef?.current) {
+        innerRef.current.setCustomValidity(invalid ?? "");
+      }
+    }, [invalid]);
+
+    return (
+      <textarea
+        aria-invalid={resolvedAriaInvalid}
+        ref={(el) => {
+          innerRef.current = el;
+          if (typeof ref === "function") {
+            ref(el);
+          } else if (ref) {
+            ref.current = el;
+          }
+        }}
+        className={textareaVariant(variantProps)}
+        {...otherPropsExtracted}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { TextareaFrame, Textarea };

--- a/src/pswui/components/Toggle.tsx
+++ b/src/pswui/components/Toggle.tsx
@@ -1,0 +1,81 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+const toggleColors = {
+  disabled: "disabled:cursor-not-allowed disabled:opacity-50",
+  outline: "focus-visible:outline-black/10 dark:focus-visible:outline-white/20",
+  border: "border-neutral-300 dark:border-neutral-700",
+  background:
+    "bg-white hover:bg-neutral-100 dark:bg-black dark:hover:bg-neutral-900",
+  pressed:
+    "aria-pressed:bg-neutral-900 aria-pressed:text-white aria-pressed:hover:bg-neutral-800 dark:aria-pressed:bg-neutral-100 dark:aria-pressed:text-black dark:aria-pressed:hover:bg-neutral-200",
+};
+
+const [toggleVariants, resolveToggleVariantProps] = vcn({
+  base: `inline-flex w-fit items-center justify-center rounded-md border outline outline-1 outline-offset-2 outline-transparent transition-all ${toggleColors.border} ${toggleColors.background} ${toggleColors.pressed} ${toggleColors.outline} ${toggleColors.disabled}`,
+  variants: {
+    size: {
+      sm: "px-2 py-1 text-sm",
+      md: "px-3 py-2 text-base",
+      lg: "px-4 py-2 text-lg",
+    },
+  },
+  defaults: {
+    size: "md",
+  },
+});
+
+export interface ToggleProps
+  extends Omit<
+      React.ComponentPropsWithoutRef<"button">,
+      "aria-pressed" | "className"
+    >,
+    VariantProps<typeof toggleVariants> {
+  pressed?: boolean;
+  defaultPressed?: boolean;
+  onPressedChange?: (pressed: boolean) => void;
+}
+
+const Toggle = React.forwardRef<HTMLButtonElement, ToggleProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveToggleVariantProps(props);
+    const {
+      defaultPressed = false,
+      pressed: propPressed,
+      onClick,
+      onPressedChange,
+      type,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const [uncontrolledPressed, setUncontrolledPressed] =
+      React.useState(defaultPressed);
+    const isControlled = typeof propPressed === "boolean";
+    const pressed = propPressed ?? uncontrolledPressed;
+
+    return (
+      <button
+        {...otherPropsExtracted}
+        ref={ref}
+        type={type ?? "button"}
+        aria-pressed={pressed}
+        className={toggleVariants(variantProps)}
+        onClick={(event) => {
+          onClick?.(event);
+
+          if (event.defaultPrevented) return;
+
+          const nextPressed = !pressed;
+          if (!isControlled) {
+            setUncontrolledPressed(nextPressed);
+          }
+          onPressedChange?.(nextPressed);
+        }}
+      />
+    );
+  },
+);
+Toggle.displayName = "Toggle";
+
+export { Toggle };

--- a/src/pswui/components/ToggleGroup.tsx
+++ b/src/pswui/components/ToggleGroup.tsx
@@ -1,0 +1,190 @@
+import { type VariantProps, vcn } from "@pswui-lib";
+import React from "react";
+
+import { Toggle, type ToggleProps } from "./Toggle";
+
+const [toggleGroupVariants, resolveToggleGroupVariantProps] = vcn({
+  base: "flex w-fit gap-2",
+  variants: {
+    orientation: {
+      horizontal: "flex-row flex-wrap items-center",
+      vertical: "flex-col items-start",
+    },
+  },
+  defaults: {
+    orientation: "horizontal",
+  },
+});
+
+interface ToggleGroupContextValue {
+  disabled?: boolean;
+  isItemPressed: (value: string) => boolean;
+  onItemPressedChange: (value: string, pressed: boolean) => void;
+  size?: ToggleProps["size"];
+}
+
+const ToggleGroupContext = React.createContext<ToggleGroupContextValue | null>(
+  null,
+);
+
+const useToggleGroupContext = () => {
+  const context = React.useContext(ToggleGroupContext);
+
+  if (!context) {
+    throw new Error("ToggleGroupItem must be used within ToggleGroup.");
+  }
+
+  return context;
+};
+
+interface ToggleGroupSharedProps
+  extends VariantProps<typeof toggleGroupVariants>,
+    Omit<
+      React.ComponentPropsWithoutRef<"div">,
+      "children" | "className" | "defaultValue" | "onChange" | "value"
+    > {
+  children?: React.ReactNode;
+  disabled?: boolean;
+  size?: ToggleProps["size"];
+}
+
+interface ToggleGroupSingleProps extends ToggleGroupSharedProps {
+  defaultValue?: string;
+  onValueChange?: (value: string | undefined) => void;
+  type?: "single";
+  value?: string;
+}
+
+interface ToggleGroupMultipleProps extends ToggleGroupSharedProps {
+  defaultValue?: string[];
+  onValueChange?: (value: string[]) => void;
+  type: "multiple";
+  value?: string[];
+}
+
+type ToggleGroupProps = ToggleGroupSingleProps | ToggleGroupMultipleProps;
+
+const ToggleGroup = React.forwardRef<HTMLDivElement, ToggleGroupProps>(
+  (props, ref) => {
+    const [variantProps, otherPropsCompressed] =
+      resolveToggleGroupVariantProps(props);
+    const {
+      children,
+      defaultValue: _defaultValue,
+      disabled,
+      onValueChange: _onValueChange,
+      role,
+      size,
+      type = "single",
+      value: _value,
+      ...otherPropsExtracted
+    } = otherPropsCompressed;
+
+    const isMultiple = type === "multiple";
+    const singleProps = props as ToggleGroupSingleProps;
+    const multipleProps = props as ToggleGroupMultipleProps;
+
+    const defaultValue = isMultiple
+      ? multipleProps.defaultValue ?? []
+      : singleProps.defaultValue;
+    const propValue = isMultiple ? multipleProps.value : singleProps.value;
+    const [uncontrolledValue, setUncontrolledValue] = React.useState<
+      string | string[] | undefined
+    >(defaultValue);
+    const isControlled = Object.prototype.hasOwnProperty.call(props, "value");
+    const value = isControlled ? propValue : uncontrolledValue;
+
+    const setValue = (nextValue: string | string[] | undefined) => {
+      if (!isControlled) {
+        setUncontrolledValue(nextValue);
+      }
+
+      if (isMultiple) {
+        multipleProps.onValueChange?.(
+          Array.isArray(nextValue) ? nextValue : [],
+        );
+        return;
+      }
+
+      singleProps.onValueChange?.(
+        typeof nextValue === "string" ? nextValue : undefined,
+      );
+    };
+
+    const contextValue = {
+      disabled,
+      isItemPressed: (itemValue: string) => {
+        if (isMultiple) {
+          return Array.isArray(value) ? value.includes(itemValue) : false;
+        }
+
+        return value === itemValue;
+      },
+      onItemPressedChange: (itemValue: string, pressed: boolean) => {
+        if (isMultiple) {
+          const currentValue = Array.isArray(value) ? value : [];
+          const nextValue = pressed
+            ? [...currentValue, itemValue]
+            : currentValue.filter(
+                (currentItemValue) => currentItemValue !== itemValue,
+              );
+
+          setValue(nextValue);
+          return;
+        }
+
+        setValue(pressed ? itemValue : undefined);
+      },
+      size,
+    } satisfies ToggleGroupContextValue;
+
+    const orientation = variantProps.orientation ?? "horizontal";
+
+    return (
+      <ToggleGroupContext.Provider value={contextValue}>
+        <div
+          {...otherPropsExtracted}
+          ref={ref}
+          role={role ?? "toolbar"}
+          aria-disabled={disabled ? true : undefined}
+          aria-orientation={orientation}
+          className={toggleGroupVariants(variantProps)}
+        >
+          {children}
+        </div>
+      </ToggleGroupContext.Provider>
+    );
+  },
+);
+ToggleGroup.displayName = "ToggleGroup";
+
+interface ToggleGroupItemProps
+  extends Omit<ToggleProps, "defaultPressed" | "pressed"> {
+  value: string;
+}
+
+const ToggleGroupItem = React.forwardRef<
+  HTMLButtonElement,
+  ToggleGroupItemProps
+>((props, ref) => {
+  const { disabled, onPressedChange, size, value, ...otherPropsExtracted } =
+    props;
+  const group = useToggleGroupContext();
+
+  return (
+    <Toggle
+      {...otherPropsExtracted}
+      ref={ref}
+      disabled={group.disabled || disabled}
+      pressed={group.isItemPressed(value)}
+      size={size ?? group.size}
+      onPressedChange={(pressed) => {
+        group.onItemPressedChange(value, pressed);
+        onPressedChange?.(pressed);
+      }}
+    />
+  );
+});
+ToggleGroupItem.displayName = "ToggleGroupItem";
+
+export { ToggleGroup, ToggleGroupItem };


### PR DESCRIPTION
## Summary

Added documentation for 19 new UI components from pswui/ui:

### Components Documented
- **Accordion** - Collapsible accordion component
- **Alert** - Callout for important information  
- **Avatar** - User profile picture with fallback initials
- **Badge** - Status badge/label
- **Breadcrumb** - Navigation path with links
- **Card** - Container with header, content, footer sections
- **Form** - Form layout with validation support (FormItem, FormLabel, FormHelper, FormError)
- **Pagination** - Page navigation control
- **Progress** - Progress bar
- **RadioGroup** - Single selection radio buttons
- **ScrollArea** - Container with styled scrollbars
- **Select** - Dropdown select component
- **Separator** - Visual divider
- **Skeleton** - Loading placeholder
- **Slider** - Range slider input
- **Table** - Data table with header, body, footer
- **Textarea** - Multi-line text input
- **Toggle** - Toggle button
- **ToggleGroup** - Group of toggle buttons

### Changes
- Created MDX documentation pages for each component
- Added Example blocks with multiple usage variants
- Copied component source files to `src/pswui/components/` to support documentation examples
- All examples follow the existing docs patterns

### Verification
- Build passed: `bun run build` succeeds
- TypeScript compilation successful

CC @p-sw