### PR TITLE
feat: rewrite newer docs pages from scratch

### DIFF
--- a/src/components/Playground.tsx
+++ b/src/components/Playground.tsx
@@ -1,8 +1,7 @@
-import { Button } from "@pswui/Button";
 import { Checkbox } from "@pswui/Checkbox";
 import { Input } from "@pswui/Input";
 import { Label } from "@pswui/Label";
-import { Popover, PopoverContent, PopoverTrigger } from "@pswui/Popover";
+import { Select } from "@pswui/Select";
 import { Switch } from "@pswui/Switch";
 import { TabContent, TabList, TabProvider, TabTrigger } from "@pswui/Tabs";
 import type { ReactNode } from "react";
@@ -109,27 +108,17 @@ export function PlaygroundControl<T extends ControlTemplate>(props: {
                     className="w-full md:w-fit"
                   />
                 ) : propMeta.type === "select" ? (
-                  <Popover>
-                    <PopoverTrigger>
-                      <Button
-                        preset="default"
-                        className="w-full md:w-fit"
-                      >
-                        {propMeta.value}
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent className="min-w-36">
-                      {propMeta.options.map((value) => (
-                        <Button
-                          preset="ghost"
-                          key={value}
-                          onClick={() => propMeta.onChange(value)}
-                        >
-                          {value}
-                        </Button>
-                      ))}
-                    </PopoverContent>
-                  </Popover>
+                  <Select
+                    full
+                    value={propMeta.value}
+                    onValueChange={propMeta.onChange}
+                    disabled={propMeta.disabled}
+                    options={propMeta.options.map((value) => ({
+                      label: value,
+                      value,
+                    }))}
+                    placeholder={propName}
+                  />
                 ) : propMeta.type === "number" ? (
                   <Input
                     type="number"


### PR DESCRIPTION
Rewrites the newer component docs pages from scratch on a clean origin/main base, using the original docs pattern as the reference point.

Highlights:
- Restored consistent MDX page structure across the newer components
- Added real Button-style playground blocks and controls
- Kept the existing docs app architecture intact and avoided new dependencies

@p-sw