### PR TITLE
fix(select): use svg chevron in docs build

### DIFF
--- a/src/pswui/components/Select.tsx
+++ b/src/pswui/components/Select.tsx
@@ -310,7 +310,21 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
               opened ? "rotate-180" : ""
             }`}
           >
-            v
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              className="size-full"
+            >
+              <title>Open options</title>
+              <path
+                d="m6 9 6 6 6-6"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
           </span>
         </button>
         <div


### PR DESCRIPTION
Updates the docs build Select trigger to use the new SVG chevron instead of the text fallback.

@p-sw