### PR TITLE
refactor(docs): use ScrollArea in docs surfaces

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import DynamicLayout from "./DynamicLayout";
 import ErrorBoundary from "./ErrorHandler";
 import MainLayout from "./MainLayout";
 
+import { ScrollArea } from "@pswui/ScrollArea";
 import { Tooltip, TooltipContent } from "@pswui/Tooltip";
 import React, {
   type ForwardedRef,
@@ -162,13 +163,16 @@ const overrideComponents = {
     />
   )),
   table: forwardRef<HTMLTableElement, { className?: string }>((props, ref) => (
-    <div className="overflow-auto">
+    <ScrollArea
+      orientation="horizontal"
+      className="w-full"
+    >
       <table
         ref={ref}
         {...props}
         className={`${props.className}`}
       />
-    </div>
+    </ScrollArea>
   )),
   h1: forwardRef<HTMLHeadingElement, HashedHeaderProps>(HashedHeaders("h1")),
   h2: forwardRef<HTMLHeadingElement, HashedHeaderProps>(HashedHeaders("h2")),

--- a/src/DocsLayout.tsx
+++ b/src/DocsLayout.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@pswui/ScrollArea";
 import { Link, useLocation } from "react-router-dom";
 import { Outlet } from "react-router-dom";
 import RouteObject from "./RouteObject";
@@ -6,27 +7,32 @@ function SideNav() {
   const location = useLocation();
 
   return (
-    <nav className="sticky top-16 overflow-auto max-h-[calc(100vh-4rem)] md:flex flex-col justify-start items-start gap-8 p-8 hidden">
-      {Object.entries(RouteObject.sideNav).map(([categoryName, links]) => {
-        return (
-          <section
-            className="flex flex-col gap-2 justify-center items-start"
-            key={categoryName}
-          >
-            <span className="font-bold">{categoryName}</span>
-            {links.map((link) => (
-              <Link
-                to={link.path}
-                key={link.path}
-                className="text-sm text-neutral-500 hover:text-neutral-700 data-[active=true]:text-current"
-                data-active={link.eq(location.pathname)}
-              >
-                {link.name}
-              </Link>
-            ))}
-          </section>
-        );
-      })}
+    <nav
+      aria-label="Documentation navigation"
+      className="sticky top-16 hidden md:block"
+    >
+      <ScrollArea className="flex max-h-[calc(100vh-4rem)] w-full flex-col items-start gap-8 p-8">
+        {Object.entries(RouteObject.sideNav).map(([categoryName, links]) => {
+          return (
+            <section
+              className="flex flex-col gap-2 justify-center items-start"
+              key={categoryName}
+            >
+              <span className="font-bold">{categoryName}</span>
+              {links.map((link) => (
+                <Link
+                  to={link.path}
+                  key={link.path}
+                  className="text-sm text-neutral-500 hover:text-neutral-700 data-[active=true]:text-current"
+                  data-active={link.eq(location.pathname)}
+                >
+                  {link.name}
+                </Link>
+              ))}
+            </section>
+          );
+        })}
+      </ScrollArea>
     </nav>
   );
 }

--- a/src/DynamicLayout.tsx
+++ b/src/DynamicLayout.tsx
@@ -1,3 +1,4 @@
+import { ScrollArea } from "@pswui/ScrollArea";
 import type { Toc } from "@stefanprobst/rehype-extract-toc";
 import { Fragment, type ReactNode, useContext, useState } from "react";
 import { useLocation } from "react-router-dom";
@@ -53,10 +54,15 @@ export default function DynamicLayout({
           {children}
         </main>
       </div>
-      <nav className="hidden lg:flex flex-col gap-2 py-8 px-4 sticky top-16 overflow-auto max-h-[calc(100vh-4rem)]">
-        <span className="font-bold text-sm">On This Page</span>
+      <nav
+        aria-label="On this page"
+        className="sticky top-16 hidden lg:block"
+      >
+        <ScrollArea className="flex max-h-[calc(100vh-4rem)] w-full flex-col gap-2 px-4 py-8">
+          <span className="font-bold text-sm">On This Page</span>
 
-        <RecursivelyToc toc={toc} />
+          <RecursivelyToc toc={toc} />
+        </ScrollArea>
       </nav>
     </HeadingContext.Provider>
   );

--- a/src/MainLayout.tsx
+++ b/src/MainLayout.tsx
@@ -7,6 +7,7 @@ import {
   DrawerTrigger,
 } from "@pswui/Drawer";
 import { Popover, PopoverContent, PopoverTrigger } from "@pswui/Popover";
+import { ScrollArea } from "@pswui/ScrollArea";
 import { Toaster } from "@pswui/Toast";
 import { useEffect, useState } from "react";
 import { Link, Outlet, useLocation } from "react-router-dom";
@@ -151,7 +152,7 @@ function TopNav() {
                 </Button>
               </DrawerTrigger>
               <DrawerOverlay className="z-99">
-                <DrawerContent className="w-[300px] overflow-auto">
+                <DrawerContent className="w-[300px] overflow-hidden">
                   <DrawerClose className="absolute top-4 right-4">
                     <Button
                       preset="ghost"
@@ -172,49 +173,54 @@ function TopNav() {
                       </svg>
                     </Button>
                   </DrawerClose>
-                  <div className="flex flex-col justify-start items-start gap-6 text-lg">
-                    <div className="flex flex-col justify-start items-start gap-3">
-                      <DrawerClose>
-                        <Link
-                          to="/"
-                          className="font-extrabold"
-                        >
-                          PSW/UI
-                        </Link>
-                      </DrawerClose>
-                      {RouteObject.mainNav.map((link) => {
-                        return (
-                          <DrawerClose key={link.path}>
-                            <Link to={link.path}>{link.name}</Link>
-                          </DrawerClose>
-                        );
-                      })}
-                    </div>
-                    {Object.entries(RouteObject.sideNav).map(
-                      ([categoryName, links]) => {
-                        return (
-                          <div
-                            className="flex flex-col justify-start items-start gap-3"
-                            key={categoryName}
+                  <ScrollArea
+                    aria-label="Documentation links"
+                    className="min-h-0 flex-1 pr-10"
+                  >
+                    <div className="flex flex-col justify-start items-start gap-6 text-lg">
+                      <div className="flex flex-col justify-start items-start gap-3">
+                        <DrawerClose>
+                          <Link
+                            to="/"
+                            className="font-extrabold"
                           >
-                            <h2 className="font-bold">{categoryName}</h2>
-                            {links.map((link) => {
-                              return (
-                                <DrawerClose key={link.path}>
-                                  <Link
-                                    to={link.path}
-                                    className="text-base opacity-75"
-                                  >
-                                    {link.name}
-                                  </Link>
-                                </DrawerClose>
-                              );
-                            })}
-                          </div>
-                        );
-                      },
-                    )}
-                  </div>
+                            PSW/UI
+                          </Link>
+                        </DrawerClose>
+                        {RouteObject.mainNav.map((link) => {
+                          return (
+                            <DrawerClose key={link.path}>
+                              <Link to={link.path}>{link.name}</Link>
+                            </DrawerClose>
+                          );
+                        })}
+                      </div>
+                      {Object.entries(RouteObject.sideNav).map(
+                        ([categoryName, links]) => {
+                          return (
+                            <div
+                              className="flex flex-col justify-start items-start gap-3"
+                              key={categoryName}
+                            >
+                              <h2 className="font-bold">{categoryName}</h2>
+                              {links.map((link) => {
+                                return (
+                                  <DrawerClose key={link.path}>
+                                    <Link
+                                      to={link.path}
+                                      className="text-base opacity-75"
+                                    >
+                                      {link.name}
+                                    </Link>
+                                  </DrawerClose>
+                                );
+                              })}
+                            </div>
+                          );
+                        },
+                      )}
+                    </div>
+                  </ScrollArea>
                 </DrawerContent>
               </DrawerOverlay>
             </DrawerRoot>

--- a/src/components/LoadedCode.tsx
+++ b/src/components/LoadedCode.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@pswui/Button";
+import { ScrollArea } from "@pswui/ScrollArea";
 import { useToast } from "@pswui/Toast";
 import {
   type Component,
@@ -141,14 +142,22 @@ export const LoadedCode = forwardRef<
           />
         </svg>
       </Button>
-      <SyntaxHighlighter
-        language="typescript"
-        style={duotoneSpace}
-        className={`w-full h-64 rounded-lg ${!state ? "animate-pulse" : ""} scrollbar-none resize-y`}
-        customStyle={{ padding: "1rem" }}
+      <ScrollArea
+        orientation="both"
+        className={twMerge(
+          "h-64 w-full resize-y rounded-lg",
+          !state && "animate-pulse",
+        )}
       >
-        {postProcessedCode}
-      </SyntaxHighlighter>
+        <SyntaxHighlighter
+          language="typescript"
+          style={duotoneSpace}
+          className="min-h-full w-full rounded-lg"
+          customStyle={{ margin: 0, padding: "1rem" }}
+        >
+          {postProcessedCode}
+        </SyntaxHighlighter>
+      </ScrollArea>
     </div>
   );
 });
@@ -191,14 +200,19 @@ export const Code = forwardRef<
           />
         </svg>
       </Button>
-      <SyntaxHighlighter
-        language={language}
-        style={duotoneSpace}
-        className={"w-full h-auto max-h-64 rounded-lg scrollbar-none"}
-        customStyle={{ padding: "1rem" }}
+      <ScrollArea
+        orientation="both"
+        className="w-full max-h-64 rounded-lg"
       >
-        {children}
-      </SyntaxHighlighter>
+        <SyntaxHighlighter
+          language={language}
+          style={duotoneSpace}
+          className="h-auto w-full rounded-lg"
+          customStyle={{ margin: 0, padding: "1rem" }}
+        >
+          {children}
+        </SyntaxHighlighter>
+      </ScrollArea>
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- replace raw overflow-based docs scroll containers with `@pswui/ScrollArea`
- update docs navigation, on-page toc, mdx tables, mobile drawer links, and shared code blocks to use the same scrolling treatment
- keep the change scoped to the docs app surface

## Verification
- npm run lint
- npm run build

cc @p-sw